### PR TITLE
Fix allocation size overflow in SaveAggregate

### DIFF
--- a/stores/boltdbstore/boltdbstore.go
+++ b/stores/boltdbstore/boltdbstore.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"sync"
@@ -264,6 +265,10 @@ func (s *BoltDBStore) SaveAggregate(ctx context.Context, aggregateID string, dat
 	db, err := s.openShard(shardNum)
 	if err != nil {
 		return fmt.Errorf("open shard: %w", err)
+	}
+
+	if len(data) > math.MaxInt-8 {
+		return fmt.Errorf("save aggregate: data too large (%d bytes)", len(data))
 	}
 
 	return db.Update(func(tx *bbolt.Tx) error {


### PR DESCRIPTION
## Summary
- Resolves [code-scanning alert #1](https://github.com/funinthecloud/protosource/security/code-scanning/1) (CWE-190: integer overflow)
- Adds a bounds check in `SaveAggregate` before `make([]byte, 8+len(data))` to prevent overflow when `len(data)` is near `math.MaxInt`
- Practically unreachable on 64-bit systems, but satisfies CodeQL and is good defensive practice

## Test plan
- [x] `go test ./stores/boltdbstore/` passes
- [x] `go vet ./stores/boltdbstore/` clean
- [ ] Verify CodeQL alert closes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)