### PR TITLE
Namespace event store keys, multi-aggregate Lambda, error codes

### DIFF
--- a/cmd/protoc-gen-protosource/content/lambda.gotext
+++ b/cmd/protoc-gen-protosource/content/lambda.gotext
@@ -7,6 +7,7 @@ import (
     "context"
     "encoding/json"
     "errors"
+    "fmt"
     "net/http"
     "strings"
 
@@ -53,20 +54,12 @@ func (h *Handler) RegisterRoutes(router *protosource.Router) {
 // Handle{{ $message.Name }} processes a {{ $message.Name }} command.
 func (h *Handler) Handle{{ $message.Name }}(ctx context.Context, request protosource.Request) protosource.Response {
     if request.Actor == "" {
-        return protosource.Response{
-            StatusCode: http.StatusUnauthorized,
-            Body:       `{"error":"unauthorized: no actor identity found"}`,
-            Headers:    map[string]string{"Content-Type": "application/json"},
-        }
+        return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
     }
 
     cmd := &{{ $message.Name }}{}
     if err := unmarshalCommand(request, cmd); err != nil {
-        return protosource.Response{
-            StatusCode: http.StatusBadRequest,
-            Body:       `{"error":"invalid request body"}`,
-            Headers:    map[string]string{"Content-Type": "application/json"},
-        }
+        return errorResponse(http.StatusBadRequest, "CMD_UNMARSHAL", "invalid request body", err)
     }
 
     // Override actor from auth context to prevent spoofing.
@@ -86,36 +79,20 @@ func (h *Handler) Handle{{ $message.Name }}(ctx context.Context, request protoso
 func (h *Handler) HandleGet(ctx context.Context, request protosource.Request) protosource.Response {
     id := extractID(request)
     if id == "" {
-        return protosource.Response{
-            StatusCode: http.StatusBadRequest,
-            Body:       `{"error":"missing required parameter: id"}`,
-            Headers:    map[string]string{"Content-Type": "application/json"},
-        }
+        return errorResponse(http.StatusBadRequest, "GET_NO_ID", "missing required parameter: id", nil)
     }
 
     aggregate, err := h.repo.Load(ctx, id)
     if err != nil {
         if errors.Is(err, protosource.ErrAggregateNotFound) {
-            return protosource.Response{
-                StatusCode: http.StatusNotFound,
-                Body:       `{"error":"aggregate not found"}`,
-                Headers:    map[string]string{"Content-Type": "application/json"},
-            }
+            return errorResponse(http.StatusNotFound, "GET_NOT_FOUND", "aggregate not found", nil)
         }
-        return protosource.Response{
-            StatusCode: http.StatusInternalServerError,
-            Body:       `{"error":"internal server error"}`,
-            Headers:    map[string]string{"Content-Type": "application/json"},
-        }
+        return errorResponse(http.StatusInternalServerError, "GET_LOAD", "failed to load aggregate", err)
     }
 
     body, contentType, err := marshalResponse(request, aggregate)
     if err != nil {
-        return protosource.Response{
-            StatusCode: http.StatusInternalServerError,
-            Body:       `{"error":"failed to serialize aggregate"}`,
-            Headers:    map[string]string{"Content-Type": "application/json"},
-        }
+        return errorResponse(http.StatusInternalServerError, "GET_MARSHAL", "failed to serialize aggregate", err)
     }
 
     return protosource.Response{
@@ -129,36 +106,20 @@ func (h *Handler) HandleGet(ctx context.Context, request protosource.Request) pr
 func (h *Handler) HandleHistory(ctx context.Context, request protosource.Request) protosource.Response {
     id := extractID(request)
     if id == "" {
-        return protosource.Response{
-            StatusCode: http.StatusBadRequest,
-            Body:       `{"error":"missing required parameter: id"}`,
-            Headers:    map[string]string{"Content-Type": "application/json"},
-        }
+        return errorResponse(http.StatusBadRequest, "HIST_NO_ID", "missing required parameter: id", nil)
     }
 
     history, err := h.repo.History(ctx, id)
     if err != nil {
         if errors.Is(err, protosource.ErrAggregateNotFound) {
-            return protosource.Response{
-                StatusCode: http.StatusNotFound,
-                Body:       `{"error":"aggregate not found"}`,
-                Headers:    map[string]string{"Content-Type": "application/json"},
-            }
+            return errorResponse(http.StatusNotFound, "HIST_NOT_FOUND", "aggregate not found", nil)
         }
-        return protosource.Response{
-            StatusCode: http.StatusInternalServerError,
-            Body:       `{"error":"internal server error"}`,
-            Headers:    map[string]string{"Content-Type": "application/json"},
-        }
+        return errorResponse(http.StatusInternalServerError, "HIST_LOAD", "failed to load history", err)
     }
 
     body, contentType, err := marshalResponse(request, history)
     if err != nil {
-        return protosource.Response{
-            StatusCode: http.StatusInternalServerError,
-            Body:       `{"error":"failed to serialize history"}`,
-            Headers:    map[string]string{"Content-Type": "application/json"},
-        }
+        return errorResponse(http.StatusInternalServerError, "HIST_MARSHAL", "failed to serialize history", err)
     }
 
     return protosource.Response{
@@ -229,15 +190,26 @@ func extractID(request protosource.Request) string {
     return request.QueryParameters["id"]
 }
 
+// errorResponse builds a JSON error response with a code for tracing.
+// If cause is non-nil, its message is included in the detail field.
+func errorResponse(statusCode int, code, message string, cause error) protosource.Response {
+    body := map[string]string{"error": message, "code": code}
+    if cause != nil {
+        body["detail"] = cause.Error()
+    }
+    b, _ := json.Marshal(body)
+    return protosource.Response{
+        StatusCode: statusCode,
+        Body:       string(b),
+        Headers:    map[string]string{"Content-Type": "application/json"},
+    }
+}
+
 // jsonResponse marshals a value as JSON and returns a protosource.Response.
 func jsonResponse(statusCode int, v any) protosource.Response {
     b, err := json.Marshal(v)
     if err != nil {
-        return protosource.Response{
-            StatusCode: http.StatusInternalServerError,
-            Body:       `{"error":"failed to serialize response"}`,
-            Headers:    map[string]string{"Content-Type": "application/json"},
-        }
+        return errorResponse(http.StatusInternalServerError, "JSON_MARSHAL", "failed to serialize response", err)
     }
     return protosource.Response{
         StatusCode: statusCode,
@@ -248,29 +220,20 @@ func jsonResponse(statusCode int, v any) protosource.Response {
 
 // commandErrorResponse maps protosource errors to appropriate HTTP responses.
 func commandErrorResponse(err error) protosource.Response {
-    statusCode := http.StatusInternalServerError
-    message := "internal server error"
-
     switch {
     case errors.Is(err, protosource.ErrValidationFailed):
-        statusCode = http.StatusBadRequest
-        message = err.Error()
+        return errorResponse(http.StatusBadRequest, "CMD_VALIDATION", err.Error(), nil)
     case errors.Is(err, protosource.ErrEmptyAggregateId):
-        statusCode = http.StatusBadRequest
-        message = "aggregate id is required"
+        return errorResponse(http.StatusBadRequest, "CMD_EMPTY_ID", "aggregate id is required", nil)
     case errors.Is(err, protosource.ErrAlreadyCreated):
-        statusCode = http.StatusConflict
-        message = "aggregate already exists"
+        return errorResponse(http.StatusConflict, "CMD_ALREADY_CREATED", "aggregate already exists", nil)
     case errors.Is(err, protosource.ErrNotCreatedYet):
-        statusCode = http.StatusNotFound
-        message = "aggregate not found"
+        return errorResponse(http.StatusNotFound, "CMD_NOT_CREATED", "aggregate not found", nil)
     case errors.Is(err, protosource.ErrAggregateNotFound):
-        statusCode = http.StatusNotFound
-        message = "aggregate not found"
+        return errorResponse(http.StatusNotFound, "CMD_NOT_FOUND", "aggregate not found", nil)
     case errors.Is(err, protosource.ErrUnauthorized):
-        statusCode = http.StatusForbidden
-        message = "command not authorized"
+        return errorResponse(http.StatusForbidden, "CMD_UNAUTHORIZED", "command not authorized", nil)
+    default:
+        return errorResponse(http.StatusInternalServerError, "CMD_INTERNAL", fmt.Sprintf("internal error: %s", err), nil)
     }
-
-    return jsonResponse(statusCode, map[string]string{"error": message})
 }

--- a/cmd/testdynamo/main.go
+++ b/cmd/testdynamo/main.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/funinthecloud/protosource"
 	"github.com/funinthecloud/protosource/adapters/awslambda"
+	orderv1 "github.com/funinthecloud/protosource/example/app/order/v1"
+	samplev1 "github.com/funinthecloud/protosource/example/app/sample/v1"
 	testv1 "github.com/funinthecloud/protosource/example/app/test/v1"
 	opaquedynamo "github.com/funinthecloud/protosource/opaquedata/dynamo"
 	"github.com/funinthecloud/protosource/serializers/protobinaryserializer"
@@ -39,11 +41,11 @@ func main() {
 	}
 
 	serializer := protobinaryserializer.NewSerializer()
-	repo := testv1.NewRepository(store, serializer)
 
-	h := testv1.NewHandler(repo)
 	router := protosource.NewRouter()
-	h.RegisterRoutes(router)
+	testv1.NewHandler(testv1.NewRepository(store, serializer)).RegisterRoutes(router)
+	orderv1.NewHandler(orderv1.NewRepository(store, serializer)).RegisterRoutes(router)
+	samplev1.NewHandler(samplev1.NewRepository(store, serializer)).RegisterRoutes(router)
 
 	handler := awslambda.WrapRouter(router, extractActor)
 	lambda.Start(handler)

--- a/example/app/order/v1/order_v1.protosource.lambda.pb.go
+++ b/example/app/order/v1/order_v1.protosource.lambda.pb.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -57,20 +58,12 @@ func (h *Handler) RegisterRoutes(router *protosource.Router) {
 // HandleCreate processes a Create command.
 func (h *Handler) HandleCreate(ctx context.Context, request protosource.Request) protosource.Response {
 	if request.Actor == "" {
-		return protosource.Response{
-			StatusCode: http.StatusUnauthorized,
-			Body:       `{"error":"unauthorized: no actor identity found"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
 	}
 
 	cmd := &Create{}
 	if err := unmarshalCommand(request, cmd); err != nil {
-		return protosource.Response{
-			StatusCode: http.StatusBadRequest,
-			Body:       `{"error":"invalid request body"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusBadRequest, "CMD_UNMARSHAL", "invalid request body", err)
 	}
 
 	// Override actor from auth context to prevent spoofing.
@@ -87,20 +80,12 @@ func (h *Handler) HandleCreate(ctx context.Context, request protosource.Request)
 // HandleAddItem processes a AddItem command.
 func (h *Handler) HandleAddItem(ctx context.Context, request protosource.Request) protosource.Response {
 	if request.Actor == "" {
-		return protosource.Response{
-			StatusCode: http.StatusUnauthorized,
-			Body:       `{"error":"unauthorized: no actor identity found"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
 	}
 
 	cmd := &AddItem{}
 	if err := unmarshalCommand(request, cmd); err != nil {
-		return protosource.Response{
-			StatusCode: http.StatusBadRequest,
-			Body:       `{"error":"invalid request body"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusBadRequest, "CMD_UNMARSHAL", "invalid request body", err)
 	}
 
 	// Override actor from auth context to prevent spoofing.
@@ -117,20 +102,12 @@ func (h *Handler) HandleAddItem(ctx context.Context, request protosource.Request
 // HandleRemoveItem processes a RemoveItem command.
 func (h *Handler) HandleRemoveItem(ctx context.Context, request protosource.Request) protosource.Response {
 	if request.Actor == "" {
-		return protosource.Response{
-			StatusCode: http.StatusUnauthorized,
-			Body:       `{"error":"unauthorized: no actor identity found"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
 	}
 
 	cmd := &RemoveItem{}
 	if err := unmarshalCommand(request, cmd); err != nil {
-		return protosource.Response{
-			StatusCode: http.StatusBadRequest,
-			Body:       `{"error":"invalid request body"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusBadRequest, "CMD_UNMARSHAL", "invalid request body", err)
 	}
 
 	// Override actor from auth context to prevent spoofing.
@@ -147,20 +124,12 @@ func (h *Handler) HandleRemoveItem(ctx context.Context, request protosource.Requ
 // HandleAddTag processes a AddTag command.
 func (h *Handler) HandleAddTag(ctx context.Context, request protosource.Request) protosource.Response {
 	if request.Actor == "" {
-		return protosource.Response{
-			StatusCode: http.StatusUnauthorized,
-			Body:       `{"error":"unauthorized: no actor identity found"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
 	}
 
 	cmd := &AddTag{}
 	if err := unmarshalCommand(request, cmd); err != nil {
-		return protosource.Response{
-			StatusCode: http.StatusBadRequest,
-			Body:       `{"error":"invalid request body"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusBadRequest, "CMD_UNMARSHAL", "invalid request body", err)
 	}
 
 	// Override actor from auth context to prevent spoofing.
@@ -177,20 +146,12 @@ func (h *Handler) HandleAddTag(ctx context.Context, request protosource.Request)
 // HandleRemoveTag processes a RemoveTag command.
 func (h *Handler) HandleRemoveTag(ctx context.Context, request protosource.Request) protosource.Response {
 	if request.Actor == "" {
-		return protosource.Response{
-			StatusCode: http.StatusUnauthorized,
-			Body:       `{"error":"unauthorized: no actor identity found"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
 	}
 
 	cmd := &RemoveTag{}
 	if err := unmarshalCommand(request, cmd); err != nil {
-		return protosource.Response{
-			StatusCode: http.StatusBadRequest,
-			Body:       `{"error":"invalid request body"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusBadRequest, "CMD_UNMARSHAL", "invalid request body", err)
 	}
 
 	// Override actor from auth context to prevent spoofing.
@@ -207,20 +168,12 @@ func (h *Handler) HandleRemoveTag(ctx context.Context, request protosource.Reque
 // HandleSetShipping processes a SetShipping command.
 func (h *Handler) HandleSetShipping(ctx context.Context, request protosource.Request) protosource.Response {
 	if request.Actor == "" {
-		return protosource.Response{
-			StatusCode: http.StatusUnauthorized,
-			Body:       `{"error":"unauthorized: no actor identity found"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
 	}
 
 	cmd := &SetShipping{}
 	if err := unmarshalCommand(request, cmd); err != nil {
-		return protosource.Response{
-			StatusCode: http.StatusBadRequest,
-			Body:       `{"error":"invalid request body"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusBadRequest, "CMD_UNMARSHAL", "invalid request body", err)
 	}
 
 	// Override actor from auth context to prevent spoofing.
@@ -237,20 +190,12 @@ func (h *Handler) HandleSetShipping(ctx context.Context, request protosource.Req
 // HandlePlace processes a Place command.
 func (h *Handler) HandlePlace(ctx context.Context, request protosource.Request) protosource.Response {
 	if request.Actor == "" {
-		return protosource.Response{
-			StatusCode: http.StatusUnauthorized,
-			Body:       `{"error":"unauthorized: no actor identity found"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
 	}
 
 	cmd := &Place{}
 	if err := unmarshalCommand(request, cmd); err != nil {
-		return protosource.Response{
-			StatusCode: http.StatusBadRequest,
-			Body:       `{"error":"invalid request body"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusBadRequest, "CMD_UNMARSHAL", "invalid request body", err)
 	}
 
 	// Override actor from auth context to prevent spoofing.
@@ -267,20 +212,12 @@ func (h *Handler) HandlePlace(ctx context.Context, request protosource.Request) 
 // HandleCancel processes a Cancel command.
 func (h *Handler) HandleCancel(ctx context.Context, request protosource.Request) protosource.Response {
 	if request.Actor == "" {
-		return protosource.Response{
-			StatusCode: http.StatusUnauthorized,
-			Body:       `{"error":"unauthorized: no actor identity found"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
 	}
 
 	cmd := &Cancel{}
 	if err := unmarshalCommand(request, cmd); err != nil {
-		return protosource.Response{
-			StatusCode: http.StatusBadRequest,
-			Body:       `{"error":"invalid request body"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusBadRequest, "CMD_UNMARSHAL", "invalid request body", err)
 	}
 
 	// Override actor from auth context to prevent spoofing.
@@ -298,36 +235,20 @@ func (h *Handler) HandleCancel(ctx context.Context, request protosource.Request)
 func (h *Handler) HandleGet(ctx context.Context, request protosource.Request) protosource.Response {
 	id := extractID(request)
 	if id == "" {
-		return protosource.Response{
-			StatusCode: http.StatusBadRequest,
-			Body:       `{"error":"missing required parameter: id"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusBadRequest, "GET_NO_ID", "missing required parameter: id", nil)
 	}
 
 	aggregate, err := h.repo.Load(ctx, id)
 	if err != nil {
 		if errors.Is(err, protosource.ErrAggregateNotFound) {
-			return protosource.Response{
-				StatusCode: http.StatusNotFound,
-				Body:       `{"error":"aggregate not found"}`,
-				Headers:    map[string]string{"Content-Type": "application/json"},
-			}
+			return errorResponse(http.StatusNotFound, "GET_NOT_FOUND", "aggregate not found", nil)
 		}
-		return protosource.Response{
-			StatusCode: http.StatusInternalServerError,
-			Body:       `{"error":"internal server error"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusInternalServerError, "GET_LOAD", "failed to load aggregate", err)
 	}
 
 	body, contentType, err := marshalResponse(request, aggregate)
 	if err != nil {
-		return protosource.Response{
-			StatusCode: http.StatusInternalServerError,
-			Body:       `{"error":"failed to serialize aggregate"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusInternalServerError, "GET_MARSHAL", "failed to serialize aggregate", err)
 	}
 
 	return protosource.Response{
@@ -341,36 +262,20 @@ func (h *Handler) HandleGet(ctx context.Context, request protosource.Request) pr
 func (h *Handler) HandleHistory(ctx context.Context, request protosource.Request) protosource.Response {
 	id := extractID(request)
 	if id == "" {
-		return protosource.Response{
-			StatusCode: http.StatusBadRequest,
-			Body:       `{"error":"missing required parameter: id"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusBadRequest, "HIST_NO_ID", "missing required parameter: id", nil)
 	}
 
 	history, err := h.repo.History(ctx, id)
 	if err != nil {
 		if errors.Is(err, protosource.ErrAggregateNotFound) {
-			return protosource.Response{
-				StatusCode: http.StatusNotFound,
-				Body:       `{"error":"aggregate not found"}`,
-				Headers:    map[string]string{"Content-Type": "application/json"},
-			}
+			return errorResponse(http.StatusNotFound, "HIST_NOT_FOUND", "aggregate not found", nil)
 		}
-		return protosource.Response{
-			StatusCode: http.StatusInternalServerError,
-			Body:       `{"error":"internal server error"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusInternalServerError, "HIST_LOAD", "failed to load history", err)
 	}
 
 	body, contentType, err := marshalResponse(request, history)
 	if err != nil {
-		return protosource.Response{
-			StatusCode: http.StatusInternalServerError,
-			Body:       `{"error":"failed to serialize history"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusInternalServerError, "HIST_MARSHAL", "failed to serialize history", err)
 	}
 
 	return protosource.Response{
@@ -441,15 +346,26 @@ func extractID(request protosource.Request) string {
 	return request.QueryParameters["id"]
 }
 
+// errorResponse builds a JSON error response with a code for tracing.
+// If cause is non-nil, its message is included in the detail field.
+func errorResponse(statusCode int, code, message string, cause error) protosource.Response {
+	body := map[string]string{"error": message, "code": code}
+	if cause != nil {
+		body["detail"] = cause.Error()
+	}
+	b, _ := json.Marshal(body)
+	return protosource.Response{
+		StatusCode: statusCode,
+		Body:       string(b),
+		Headers:    map[string]string{"Content-Type": "application/json"},
+	}
+}
+
 // jsonResponse marshals a value as JSON and returns a protosource.Response.
 func jsonResponse(statusCode int, v any) protosource.Response {
 	b, err := json.Marshal(v)
 	if err != nil {
-		return protosource.Response{
-			StatusCode: http.StatusInternalServerError,
-			Body:       `{"error":"failed to serialize response"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusInternalServerError, "JSON_MARSHAL", "failed to serialize response", err)
 	}
 	return protosource.Response{
 		StatusCode: statusCode,
@@ -460,29 +376,20 @@ func jsonResponse(statusCode int, v any) protosource.Response {
 
 // commandErrorResponse maps protosource errors to appropriate HTTP responses.
 func commandErrorResponse(err error) protosource.Response {
-	statusCode := http.StatusInternalServerError
-	message := "internal server error"
-
 	switch {
 	case errors.Is(err, protosource.ErrValidationFailed):
-		statusCode = http.StatusBadRequest
-		message = err.Error()
+		return errorResponse(http.StatusBadRequest, "CMD_VALIDATION", err.Error(), nil)
 	case errors.Is(err, protosource.ErrEmptyAggregateId):
-		statusCode = http.StatusBadRequest
-		message = "aggregate id is required"
+		return errorResponse(http.StatusBadRequest, "CMD_EMPTY_ID", "aggregate id is required", nil)
 	case errors.Is(err, protosource.ErrAlreadyCreated):
-		statusCode = http.StatusConflict
-		message = "aggregate already exists"
+		return errorResponse(http.StatusConflict, "CMD_ALREADY_CREATED", "aggregate already exists", nil)
 	case errors.Is(err, protosource.ErrNotCreatedYet):
-		statusCode = http.StatusNotFound
-		message = "aggregate not found"
+		return errorResponse(http.StatusNotFound, "CMD_NOT_CREATED", "aggregate not found", nil)
 	case errors.Is(err, protosource.ErrAggregateNotFound):
-		statusCode = http.StatusNotFound
-		message = "aggregate not found"
+		return errorResponse(http.StatusNotFound, "CMD_NOT_FOUND", "aggregate not found", nil)
 	case errors.Is(err, protosource.ErrUnauthorized):
-		statusCode = http.StatusForbidden
-		message = "command not authorized"
+		return errorResponse(http.StatusForbidden, "CMD_UNAUTHORIZED", "command not authorized", nil)
+	default:
+		return errorResponse(http.StatusInternalServerError, "CMD_INTERNAL", fmt.Sprintf("internal error: %s", err), nil)
 	}
-
-	return jsonResponse(statusCode, map[string]string{"error": message})
 }

--- a/example/app/sample/v1/sample_v1.protosource.lambda.pb.go
+++ b/example/app/sample/v1/sample_v1.protosource.lambda.pb.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -45,20 +46,12 @@ func (h *Handler) RegisterRoutes(router *protosource.Router) {
 // HandleCreate processes a Create command.
 func (h *Handler) HandleCreate(ctx context.Context, request protosource.Request) protosource.Response {
 	if request.Actor == "" {
-		return protosource.Response{
-			StatusCode: http.StatusUnauthorized,
-			Body:       `{"error":"unauthorized: no actor identity found"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
 	}
 
 	cmd := &Create{}
 	if err := unmarshalCommand(request, cmd); err != nil {
-		return protosource.Response{
-			StatusCode: http.StatusBadRequest,
-			Body:       `{"error":"invalid request body"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusBadRequest, "CMD_UNMARSHAL", "invalid request body", err)
 	}
 
 	// Override actor from auth context to prevent spoofing.
@@ -75,20 +68,12 @@ func (h *Handler) HandleCreate(ctx context.Context, request protosource.Request)
 // HandleUpdate processes a Update command.
 func (h *Handler) HandleUpdate(ctx context.Context, request protosource.Request) protosource.Response {
 	if request.Actor == "" {
-		return protosource.Response{
-			StatusCode: http.StatusUnauthorized,
-			Body:       `{"error":"unauthorized: no actor identity found"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
 	}
 
 	cmd := &Update{}
 	if err := unmarshalCommand(request, cmd); err != nil {
-		return protosource.Response{
-			StatusCode: http.StatusBadRequest,
-			Body:       `{"error":"invalid request body"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusBadRequest, "CMD_UNMARSHAL", "invalid request body", err)
 	}
 
 	// Override actor from auth context to prevent spoofing.
@@ -106,36 +91,20 @@ func (h *Handler) HandleUpdate(ctx context.Context, request protosource.Request)
 func (h *Handler) HandleGet(ctx context.Context, request protosource.Request) protosource.Response {
 	id := extractID(request)
 	if id == "" {
-		return protosource.Response{
-			StatusCode: http.StatusBadRequest,
-			Body:       `{"error":"missing required parameter: id"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusBadRequest, "GET_NO_ID", "missing required parameter: id", nil)
 	}
 
 	aggregate, err := h.repo.Load(ctx, id)
 	if err != nil {
 		if errors.Is(err, protosource.ErrAggregateNotFound) {
-			return protosource.Response{
-				StatusCode: http.StatusNotFound,
-				Body:       `{"error":"aggregate not found"}`,
-				Headers:    map[string]string{"Content-Type": "application/json"},
-			}
+			return errorResponse(http.StatusNotFound, "GET_NOT_FOUND", "aggregate not found", nil)
 		}
-		return protosource.Response{
-			StatusCode: http.StatusInternalServerError,
-			Body:       `{"error":"internal server error"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusInternalServerError, "GET_LOAD", "failed to load aggregate", err)
 	}
 
 	body, contentType, err := marshalResponse(request, aggregate)
 	if err != nil {
-		return protosource.Response{
-			StatusCode: http.StatusInternalServerError,
-			Body:       `{"error":"failed to serialize aggregate"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusInternalServerError, "GET_MARSHAL", "failed to serialize aggregate", err)
 	}
 
 	return protosource.Response{
@@ -149,36 +118,20 @@ func (h *Handler) HandleGet(ctx context.Context, request protosource.Request) pr
 func (h *Handler) HandleHistory(ctx context.Context, request protosource.Request) protosource.Response {
 	id := extractID(request)
 	if id == "" {
-		return protosource.Response{
-			StatusCode: http.StatusBadRequest,
-			Body:       `{"error":"missing required parameter: id"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusBadRequest, "HIST_NO_ID", "missing required parameter: id", nil)
 	}
 
 	history, err := h.repo.History(ctx, id)
 	if err != nil {
 		if errors.Is(err, protosource.ErrAggregateNotFound) {
-			return protosource.Response{
-				StatusCode: http.StatusNotFound,
-				Body:       `{"error":"aggregate not found"}`,
-				Headers:    map[string]string{"Content-Type": "application/json"},
-			}
+			return errorResponse(http.StatusNotFound, "HIST_NOT_FOUND", "aggregate not found", nil)
 		}
-		return protosource.Response{
-			StatusCode: http.StatusInternalServerError,
-			Body:       `{"error":"internal server error"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusInternalServerError, "HIST_LOAD", "failed to load history", err)
 	}
 
 	body, contentType, err := marshalResponse(request, history)
 	if err != nil {
-		return protosource.Response{
-			StatusCode: http.StatusInternalServerError,
-			Body:       `{"error":"failed to serialize history"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusInternalServerError, "HIST_MARSHAL", "failed to serialize history", err)
 	}
 
 	return protosource.Response{
@@ -249,15 +202,26 @@ func extractID(request protosource.Request) string {
 	return request.QueryParameters["id"]
 }
 
+// errorResponse builds a JSON error response with a code for tracing.
+// If cause is non-nil, its message is included in the detail field.
+func errorResponse(statusCode int, code, message string, cause error) protosource.Response {
+	body := map[string]string{"error": message, "code": code}
+	if cause != nil {
+		body["detail"] = cause.Error()
+	}
+	b, _ := json.Marshal(body)
+	return protosource.Response{
+		StatusCode: statusCode,
+		Body:       string(b),
+		Headers:    map[string]string{"Content-Type": "application/json"},
+	}
+}
+
 // jsonResponse marshals a value as JSON and returns a protosource.Response.
 func jsonResponse(statusCode int, v any) protosource.Response {
 	b, err := json.Marshal(v)
 	if err != nil {
-		return protosource.Response{
-			StatusCode: http.StatusInternalServerError,
-			Body:       `{"error":"failed to serialize response"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusInternalServerError, "JSON_MARSHAL", "failed to serialize response", err)
 	}
 	return protosource.Response{
 		StatusCode: statusCode,
@@ -268,29 +232,20 @@ func jsonResponse(statusCode int, v any) protosource.Response {
 
 // commandErrorResponse maps protosource errors to appropriate HTTP responses.
 func commandErrorResponse(err error) protosource.Response {
-	statusCode := http.StatusInternalServerError
-	message := "internal server error"
-
 	switch {
 	case errors.Is(err, protosource.ErrValidationFailed):
-		statusCode = http.StatusBadRequest
-		message = err.Error()
+		return errorResponse(http.StatusBadRequest, "CMD_VALIDATION", err.Error(), nil)
 	case errors.Is(err, protosource.ErrEmptyAggregateId):
-		statusCode = http.StatusBadRequest
-		message = "aggregate id is required"
+		return errorResponse(http.StatusBadRequest, "CMD_EMPTY_ID", "aggregate id is required", nil)
 	case errors.Is(err, protosource.ErrAlreadyCreated):
-		statusCode = http.StatusConflict
-		message = "aggregate already exists"
+		return errorResponse(http.StatusConflict, "CMD_ALREADY_CREATED", "aggregate already exists", nil)
 	case errors.Is(err, protosource.ErrNotCreatedYet):
-		statusCode = http.StatusNotFound
-		message = "aggregate not found"
+		return errorResponse(http.StatusNotFound, "CMD_NOT_CREATED", "aggregate not found", nil)
 	case errors.Is(err, protosource.ErrAggregateNotFound):
-		statusCode = http.StatusNotFound
-		message = "aggregate not found"
+		return errorResponse(http.StatusNotFound, "CMD_NOT_FOUND", "aggregate not found", nil)
 	case errors.Is(err, protosource.ErrUnauthorized):
-		statusCode = http.StatusForbidden
-		message = "command not authorized"
+		return errorResponse(http.StatusForbidden, "CMD_UNAUTHORIZED", "command not authorized", nil)
+	default:
+		return errorResponse(http.StatusInternalServerError, "CMD_INTERNAL", fmt.Sprintf("internal error: %s", err), nil)
 	}
-
-	return jsonResponse(statusCode, map[string]string{"error": message})
 }

--- a/example/app/samplenosnapshot/v1/samplenosnapshot_v1.protosource.lambda.pb.go
+++ b/example/app/samplenosnapshot/v1/samplenosnapshot_v1.protosource.lambda.pb.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -45,20 +46,12 @@ func (h *Handler) RegisterRoutes(router *protosource.Router) {
 // HandleCreate processes a Create command.
 func (h *Handler) HandleCreate(ctx context.Context, request protosource.Request) protosource.Response {
 	if request.Actor == "" {
-		return protosource.Response{
-			StatusCode: http.StatusUnauthorized,
-			Body:       `{"error":"unauthorized: no actor identity found"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
 	}
 
 	cmd := &Create{}
 	if err := unmarshalCommand(request, cmd); err != nil {
-		return protosource.Response{
-			StatusCode: http.StatusBadRequest,
-			Body:       `{"error":"invalid request body"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusBadRequest, "CMD_UNMARSHAL", "invalid request body", err)
 	}
 
 	// Override actor from auth context to prevent spoofing.
@@ -75,20 +68,12 @@ func (h *Handler) HandleCreate(ctx context.Context, request protosource.Request)
 // HandleUpdate processes a Update command.
 func (h *Handler) HandleUpdate(ctx context.Context, request protosource.Request) protosource.Response {
 	if request.Actor == "" {
-		return protosource.Response{
-			StatusCode: http.StatusUnauthorized,
-			Body:       `{"error":"unauthorized: no actor identity found"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
 	}
 
 	cmd := &Update{}
 	if err := unmarshalCommand(request, cmd); err != nil {
-		return protosource.Response{
-			StatusCode: http.StatusBadRequest,
-			Body:       `{"error":"invalid request body"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusBadRequest, "CMD_UNMARSHAL", "invalid request body", err)
 	}
 
 	// Override actor from auth context to prevent spoofing.
@@ -106,36 +91,20 @@ func (h *Handler) HandleUpdate(ctx context.Context, request protosource.Request)
 func (h *Handler) HandleGet(ctx context.Context, request protosource.Request) protosource.Response {
 	id := extractID(request)
 	if id == "" {
-		return protosource.Response{
-			StatusCode: http.StatusBadRequest,
-			Body:       `{"error":"missing required parameter: id"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusBadRequest, "GET_NO_ID", "missing required parameter: id", nil)
 	}
 
 	aggregate, err := h.repo.Load(ctx, id)
 	if err != nil {
 		if errors.Is(err, protosource.ErrAggregateNotFound) {
-			return protosource.Response{
-				StatusCode: http.StatusNotFound,
-				Body:       `{"error":"aggregate not found"}`,
-				Headers:    map[string]string{"Content-Type": "application/json"},
-			}
+			return errorResponse(http.StatusNotFound, "GET_NOT_FOUND", "aggregate not found", nil)
 		}
-		return protosource.Response{
-			StatusCode: http.StatusInternalServerError,
-			Body:       `{"error":"internal server error"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusInternalServerError, "GET_LOAD", "failed to load aggregate", err)
 	}
 
 	body, contentType, err := marshalResponse(request, aggregate)
 	if err != nil {
-		return protosource.Response{
-			StatusCode: http.StatusInternalServerError,
-			Body:       `{"error":"failed to serialize aggregate"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusInternalServerError, "GET_MARSHAL", "failed to serialize aggregate", err)
 	}
 
 	return protosource.Response{
@@ -149,36 +118,20 @@ func (h *Handler) HandleGet(ctx context.Context, request protosource.Request) pr
 func (h *Handler) HandleHistory(ctx context.Context, request protosource.Request) protosource.Response {
 	id := extractID(request)
 	if id == "" {
-		return protosource.Response{
-			StatusCode: http.StatusBadRequest,
-			Body:       `{"error":"missing required parameter: id"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusBadRequest, "HIST_NO_ID", "missing required parameter: id", nil)
 	}
 
 	history, err := h.repo.History(ctx, id)
 	if err != nil {
 		if errors.Is(err, protosource.ErrAggregateNotFound) {
-			return protosource.Response{
-				StatusCode: http.StatusNotFound,
-				Body:       `{"error":"aggregate not found"}`,
-				Headers:    map[string]string{"Content-Type": "application/json"},
-			}
+			return errorResponse(http.StatusNotFound, "HIST_NOT_FOUND", "aggregate not found", nil)
 		}
-		return protosource.Response{
-			StatusCode: http.StatusInternalServerError,
-			Body:       `{"error":"internal server error"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusInternalServerError, "HIST_LOAD", "failed to load history", err)
 	}
 
 	body, contentType, err := marshalResponse(request, history)
 	if err != nil {
-		return protosource.Response{
-			StatusCode: http.StatusInternalServerError,
-			Body:       `{"error":"failed to serialize history"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusInternalServerError, "HIST_MARSHAL", "failed to serialize history", err)
 	}
 
 	return protosource.Response{
@@ -249,15 +202,26 @@ func extractID(request protosource.Request) string {
 	return request.QueryParameters["id"]
 }
 
+// errorResponse builds a JSON error response with a code for tracing.
+// If cause is non-nil, its message is included in the detail field.
+func errorResponse(statusCode int, code, message string, cause error) protosource.Response {
+	body := map[string]string{"error": message, "code": code}
+	if cause != nil {
+		body["detail"] = cause.Error()
+	}
+	b, _ := json.Marshal(body)
+	return protosource.Response{
+		StatusCode: statusCode,
+		Body:       string(b),
+		Headers:    map[string]string{"Content-Type": "application/json"},
+	}
+}
+
 // jsonResponse marshals a value as JSON and returns a protosource.Response.
 func jsonResponse(statusCode int, v any) protosource.Response {
 	b, err := json.Marshal(v)
 	if err != nil {
-		return protosource.Response{
-			StatusCode: http.StatusInternalServerError,
-			Body:       `{"error":"failed to serialize response"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusInternalServerError, "JSON_MARSHAL", "failed to serialize response", err)
 	}
 	return protosource.Response{
 		StatusCode: statusCode,
@@ -268,29 +232,20 @@ func jsonResponse(statusCode int, v any) protosource.Response {
 
 // commandErrorResponse maps protosource errors to appropriate HTTP responses.
 func commandErrorResponse(err error) protosource.Response {
-	statusCode := http.StatusInternalServerError
-	message := "internal server error"
-
 	switch {
 	case errors.Is(err, protosource.ErrValidationFailed):
-		statusCode = http.StatusBadRequest
-		message = err.Error()
+		return errorResponse(http.StatusBadRequest, "CMD_VALIDATION", err.Error(), nil)
 	case errors.Is(err, protosource.ErrEmptyAggregateId):
-		statusCode = http.StatusBadRequest
-		message = "aggregate id is required"
+		return errorResponse(http.StatusBadRequest, "CMD_EMPTY_ID", "aggregate id is required", nil)
 	case errors.Is(err, protosource.ErrAlreadyCreated):
-		statusCode = http.StatusConflict
-		message = "aggregate already exists"
+		return errorResponse(http.StatusConflict, "CMD_ALREADY_CREATED", "aggregate already exists", nil)
 	case errors.Is(err, protosource.ErrNotCreatedYet):
-		statusCode = http.StatusNotFound
-		message = "aggregate not found"
+		return errorResponse(http.StatusNotFound, "CMD_NOT_CREATED", "aggregate not found", nil)
 	case errors.Is(err, protosource.ErrAggregateNotFound):
-		statusCode = http.StatusNotFound
-		message = "aggregate not found"
+		return errorResponse(http.StatusNotFound, "CMD_NOT_FOUND", "aggregate not found", nil)
 	case errors.Is(err, protosource.ErrUnauthorized):
-		statusCode = http.StatusForbidden
-		message = "command not authorized"
+		return errorResponse(http.StatusForbidden, "CMD_UNAUTHORIZED", "command not authorized", nil)
+	default:
+		return errorResponse(http.StatusInternalServerError, "CMD_INTERNAL", fmt.Sprintf("internal error: %s", err), nil)
 	}
-
-	return jsonResponse(statusCode, map[string]string{"error": message})
 }

--- a/example/app/test/v1/test_v1.protosource.lambda.pb.go
+++ b/example/app/test/v1/test_v1.protosource.lambda.pb.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -49,20 +50,12 @@ func (h *Handler) RegisterRoutes(router *protosource.Router) {
 // HandleCreate processes a Create command.
 func (h *Handler) HandleCreate(ctx context.Context, request protosource.Request) protosource.Response {
 	if request.Actor == "" {
-		return protosource.Response{
-			StatusCode: http.StatusUnauthorized,
-			Body:       `{"error":"unauthorized: no actor identity found"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
 	}
 
 	cmd := &Create{}
 	if err := unmarshalCommand(request, cmd); err != nil {
-		return protosource.Response{
-			StatusCode: http.StatusBadRequest,
-			Body:       `{"error":"invalid request body"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusBadRequest, "CMD_UNMARSHAL", "invalid request body", err)
 	}
 
 	// Override actor from auth context to prevent spoofing.
@@ -79,20 +72,12 @@ func (h *Handler) HandleCreate(ctx context.Context, request protosource.Request)
 // HandleUpdate processes a Update command.
 func (h *Handler) HandleUpdate(ctx context.Context, request protosource.Request) protosource.Response {
 	if request.Actor == "" {
-		return protosource.Response{
-			StatusCode: http.StatusUnauthorized,
-			Body:       `{"error":"unauthorized: no actor identity found"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
 	}
 
 	cmd := &Update{}
 	if err := unmarshalCommand(request, cmd); err != nil {
-		return protosource.Response{
-			StatusCode: http.StatusBadRequest,
-			Body:       `{"error":"invalid request body"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusBadRequest, "CMD_UNMARSHAL", "invalid request body", err)
 	}
 
 	// Override actor from auth context to prevent spoofing.
@@ -109,20 +94,12 @@ func (h *Handler) HandleUpdate(ctx context.Context, request protosource.Request)
 // HandleLock processes a Lock command.
 func (h *Handler) HandleLock(ctx context.Context, request protosource.Request) protosource.Response {
 	if request.Actor == "" {
-		return protosource.Response{
-			StatusCode: http.StatusUnauthorized,
-			Body:       `{"error":"unauthorized: no actor identity found"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
 	}
 
 	cmd := &Lock{}
 	if err := unmarshalCommand(request, cmd); err != nil {
-		return protosource.Response{
-			StatusCode: http.StatusBadRequest,
-			Body:       `{"error":"invalid request body"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusBadRequest, "CMD_UNMARSHAL", "invalid request body", err)
 	}
 
 	// Override actor from auth context to prevent spoofing.
@@ -139,20 +116,12 @@ func (h *Handler) HandleLock(ctx context.Context, request protosource.Request) p
 // HandleUnlock processes a Unlock command.
 func (h *Handler) HandleUnlock(ctx context.Context, request protosource.Request) protosource.Response {
 	if request.Actor == "" {
-		return protosource.Response{
-			StatusCode: http.StatusUnauthorized,
-			Body:       `{"error":"unauthorized: no actor identity found"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
 	}
 
 	cmd := &Unlock{}
 	if err := unmarshalCommand(request, cmd); err != nil {
-		return protosource.Response{
-			StatusCode: http.StatusBadRequest,
-			Body:       `{"error":"invalid request body"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusBadRequest, "CMD_UNMARSHAL", "invalid request body", err)
 	}
 
 	// Override actor from auth context to prevent spoofing.
@@ -170,36 +139,20 @@ func (h *Handler) HandleUnlock(ctx context.Context, request protosource.Request)
 func (h *Handler) HandleGet(ctx context.Context, request protosource.Request) protosource.Response {
 	id := extractID(request)
 	if id == "" {
-		return protosource.Response{
-			StatusCode: http.StatusBadRequest,
-			Body:       `{"error":"missing required parameter: id"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusBadRequest, "GET_NO_ID", "missing required parameter: id", nil)
 	}
 
 	aggregate, err := h.repo.Load(ctx, id)
 	if err != nil {
 		if errors.Is(err, protosource.ErrAggregateNotFound) {
-			return protosource.Response{
-				StatusCode: http.StatusNotFound,
-				Body:       `{"error":"aggregate not found"}`,
-				Headers:    map[string]string{"Content-Type": "application/json"},
-			}
+			return errorResponse(http.StatusNotFound, "GET_NOT_FOUND", "aggregate not found", nil)
 		}
-		return protosource.Response{
-			StatusCode: http.StatusInternalServerError,
-			Body:       `{"error":"internal server error"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusInternalServerError, "GET_LOAD", "failed to load aggregate", err)
 	}
 
 	body, contentType, err := marshalResponse(request, aggregate)
 	if err != nil {
-		return protosource.Response{
-			StatusCode: http.StatusInternalServerError,
-			Body:       `{"error":"failed to serialize aggregate"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusInternalServerError, "GET_MARSHAL", "failed to serialize aggregate", err)
 	}
 
 	return protosource.Response{
@@ -213,36 +166,20 @@ func (h *Handler) HandleGet(ctx context.Context, request protosource.Request) pr
 func (h *Handler) HandleHistory(ctx context.Context, request protosource.Request) protosource.Response {
 	id := extractID(request)
 	if id == "" {
-		return protosource.Response{
-			StatusCode: http.StatusBadRequest,
-			Body:       `{"error":"missing required parameter: id"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusBadRequest, "HIST_NO_ID", "missing required parameter: id", nil)
 	}
 
 	history, err := h.repo.History(ctx, id)
 	if err != nil {
 		if errors.Is(err, protosource.ErrAggregateNotFound) {
-			return protosource.Response{
-				StatusCode: http.StatusNotFound,
-				Body:       `{"error":"aggregate not found"}`,
-				Headers:    map[string]string{"Content-Type": "application/json"},
-			}
+			return errorResponse(http.StatusNotFound, "HIST_NOT_FOUND", "aggregate not found", nil)
 		}
-		return protosource.Response{
-			StatusCode: http.StatusInternalServerError,
-			Body:       `{"error":"internal server error"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusInternalServerError, "HIST_LOAD", "failed to load history", err)
 	}
 
 	body, contentType, err := marshalResponse(request, history)
 	if err != nil {
-		return protosource.Response{
-			StatusCode: http.StatusInternalServerError,
-			Body:       `{"error":"failed to serialize history"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusInternalServerError, "HIST_MARSHAL", "failed to serialize history", err)
 	}
 
 	return protosource.Response{
@@ -313,15 +250,26 @@ func extractID(request protosource.Request) string {
 	return request.QueryParameters["id"]
 }
 
+// errorResponse builds a JSON error response with a code for tracing.
+// If cause is non-nil, its message is included in the detail field.
+func errorResponse(statusCode int, code, message string, cause error) protosource.Response {
+	body := map[string]string{"error": message, "code": code}
+	if cause != nil {
+		body["detail"] = cause.Error()
+	}
+	b, _ := json.Marshal(body)
+	return protosource.Response{
+		StatusCode: statusCode,
+		Body:       string(b),
+		Headers:    map[string]string{"Content-Type": "application/json"},
+	}
+}
+
 // jsonResponse marshals a value as JSON and returns a protosource.Response.
 func jsonResponse(statusCode int, v any) protosource.Response {
 	b, err := json.Marshal(v)
 	if err != nil {
-		return protosource.Response{
-			StatusCode: http.StatusInternalServerError,
-			Body:       `{"error":"failed to serialize response"}`,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-		}
+		return errorResponse(http.StatusInternalServerError, "JSON_MARSHAL", "failed to serialize response", err)
 	}
 	return protosource.Response{
 		StatusCode: statusCode,
@@ -332,29 +280,20 @@ func jsonResponse(statusCode int, v any) protosource.Response {
 
 // commandErrorResponse maps protosource errors to appropriate HTTP responses.
 func commandErrorResponse(err error) protosource.Response {
-	statusCode := http.StatusInternalServerError
-	message := "internal server error"
-
 	switch {
 	case errors.Is(err, protosource.ErrValidationFailed):
-		statusCode = http.StatusBadRequest
-		message = err.Error()
+		return errorResponse(http.StatusBadRequest, "CMD_VALIDATION", err.Error(), nil)
 	case errors.Is(err, protosource.ErrEmptyAggregateId):
-		statusCode = http.StatusBadRequest
-		message = "aggregate id is required"
+		return errorResponse(http.StatusBadRequest, "CMD_EMPTY_ID", "aggregate id is required", nil)
 	case errors.Is(err, protosource.ErrAlreadyCreated):
-		statusCode = http.StatusConflict
-		message = "aggregate already exists"
+		return errorResponse(http.StatusConflict, "CMD_ALREADY_CREATED", "aggregate already exists", nil)
 	case errors.Is(err, protosource.ErrNotCreatedYet):
-		statusCode = http.StatusNotFound
-		message = "aggregate not found"
+		return errorResponse(http.StatusNotFound, "CMD_NOT_CREATED", "aggregate not found", nil)
 	case errors.Is(err, protosource.ErrAggregateNotFound):
-		statusCode = http.StatusNotFound
-		message = "aggregate not found"
+		return errorResponse(http.StatusNotFound, "CMD_NOT_FOUND", "aggregate not found", nil)
 	case errors.Is(err, protosource.ErrUnauthorized):
-		statusCode = http.StatusForbidden
-		message = "command not authorized"
+		return errorResponse(http.StatusForbidden, "CMD_UNAUTHORIZED", "command not authorized", nil)
+	default:
+		return errorResponse(http.StatusInternalServerError, "CMD_INTERNAL", fmt.Sprintf("internal error: %s", err), nil)
 	}
-
-	return jsonResponse(statusCode, map[string]string{"error": message})
 }

--- a/example/app/test/v1/testmgr/main.go
+++ b/example/app/test/v1/testmgr/main.go
@@ -299,7 +299,7 @@ func loadHistory(id string) {
 			continue
 		}
 
-		fmt.Printf("v%d %s\n%s\n", record.GetVersion(), typeName, string(b))
+		fmt.Printf("v%d %s\n%s\n\n", record.GetVersion(), typeName, string(b))
 	}
 }
 

--- a/protosource.go
+++ b/protosource.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 	"time"
 
 	historyv1 "github.com/funinthecloud/protosource/history/v1"
@@ -175,6 +176,7 @@ type Repository struct {
 	serializer        Serializer   // Converts between events and records
 	compressThreshold int          // 0 = disabled; >0 = compress data at or above this byte size
 	logger            Logger       // diagnostic logging for best-effort operations
+	keyPrefix         string       // proto full name prefix for namespacing event store keys
 }
 
 // New creates a new Repository with the given prototype, store, and serializer.
@@ -197,12 +199,17 @@ func New(prototype Aggregate, store Store, serializer Serializer, opts ...Option
 		t = t.Elem()
 	}
 
+	// Derive key prefix from proto package name: example.app.test.v1 → example_app_test_v1#
+	pkg := string(prototype.ProtoReflect().Descriptor().ParentFile().Package())
+	prefix := strings.ReplaceAll(pkg, ".", "_") + "#"
+
 	r := &Repository{
 		prototype:         t,
 		store:             store,
 		serializer:        serializer,
 		compressThreshold: DefaultCompressThreshold,
 		logger:            noopLogger{},
+		keyPrefix:         prefix,
 	}
 
 	for _, opt := range opts {
@@ -210,6 +217,12 @@ func New(prototype Aggregate, store Store, serializer Serializer, opts ...Option
 	}
 
 	return r
+}
+
+// qualifiedID prefixes the aggregate ID with the proto package namespace
+// to prevent key collisions across aggregate types sharing the same store.
+func (r *Repository) qualifiedID(id string) string {
+	return r.keyPrefix + id
 }
 
 // Option provides functional configuration options for the Repository
@@ -259,7 +272,7 @@ func (r *Repository) History(ctx context.Context, aggregateID string) (*historyv
 	if aggregateID == "" {
 		return nil, ErrEmptyAggregateId
 	}
-	history, err := r.store.Load(ctx, aggregateID)
+	history, err := r.store.Load(ctx, r.qualifiedID(aggregateID))
 	if err != nil {
 		return nil, err
 	}
@@ -427,7 +440,7 @@ func (r *Repository) Save(ctx context.Context, events ...Event) error {
 		}
 	}
 
-	return r.store.Save(ctx, aggregateID, h.GetRecords()...)
+	return r.store.Save(ctx, r.qualifiedID(aggregateID), h.GetRecords()...)
 }
 
 var (
@@ -498,19 +511,20 @@ func (r *Repository) loadAggregateVersion(ctx context.Context, aggregateId strin
 // SnapshotTailStore and the aggregate prototype has a snapshot interval, it
 // loads only the last interval-worth of events instead of the entire history.
 func (r *Repository) loadHistory(ctx context.Context, aggregateId string) (*historyv1.History, error) {
+	qid := r.qualifiedID(aggregateId)
 	sts, isSTS := r.store.(SnapshotTailStore)
 	if !isSTS {
-		return r.store.Load(ctx, aggregateId)
+		return r.store.Load(ctx, qid)
 	}
 
 	// Check if the aggregate prototype supports snapshots.
 	p := r.new()
 	snapshoter, hasSnapshots := p.(Snapshoter)
 	if !hasSnapshots || snapshoter.SnapshotInterval() <= 0 {
-		return r.store.Load(ctx, aggregateId)
+		return r.store.Load(ctx, qid)
 	}
 
-	return sts.LoadTail(ctx, aggregateId, int(snapshoter.SnapshotInterval()))
+	return sts.LoadTail(ctx, qid, int(snapshoter.SnapshotInterval()))
 }
 
 // EventEmitter is implemented by generated command types that can produce events.

--- a/protosource_test.go
+++ b/protosource_test.go
@@ -892,8 +892,8 @@ func TestSnapshot_CapturesPostEventState(t *testing.T) {
 		t.Fatalf("update failed: %v", err)
 	}
 
-	// Load the raw history and find the snapshot event.
-	history, err := store.Load(ctx, "id-1")
+	// Load the history via repo and find the snapshot event.
+	history, err := repo.History(ctx, "id-1")
 	if err != nil {
 		t.Fatalf("load history failed: %v", err)
 	}
@@ -950,7 +950,7 @@ func TestSnapshot_MultiEventBoundaryCrossing(t *testing.T) {
 		}
 	}
 
-	history, err := store.Load(ctx, "id-1")
+	history, err := repo.History(ctx, "id-1")
 	if err != nil {
 		t.Fatalf("load history failed: %v", err)
 	}


### PR DESCRIPTION
## Summary

- **Event store key namespacing**: Prefix events table partition key with proto package name (e.g., `example_app_test_v1#id-1`) to prevent collisions when multiple aggregate types share the same DynamoDB table
- **Multi-aggregate Lambda**: testdynamo now serves test_v1, order_v1, and sample_v1 from a single Lambda with shared router
- **Error codes in handlers**: Every generated error response now includes a `code` field (e.g., `CMD_INTERNAL`, `GET_LOAD`) and 500s include a `detail` field with the actual error message

## Breaking change

Existing events in DynamoDB have unprefixed partition keys. After deploying, old aggregates will be invisible. Clear the events table or migrate keys.

## Test plan

- [x] All tests pass (`go test ./...`)
- [x] `go build ./cmd/testdynamo` compiles with all three aggregate handlers
- [ ] Deploy and verify all three aggregates work via CLI
- [ ] Verify error codes appear in error responses