### PR TITLE
fix(dynamodbstore): propagate event TTL to materialized aggregates

### DIFF
--- a/stores/dynamodbstore/dynamodbstore.go
+++ b/stores/dynamodbstore/dynamodbstore.go
@@ -2,6 +2,7 @@ package dynamodbstore
 
 import (
 	"context"
+	"math"
 	"fmt"
 	"strconv"
 	"time"
@@ -11,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/funinthecloud/protosource/aws/dynamoclient"
 	historyv1 "github.com/funinthecloud/protosource/history/v1"
+	"github.com/funinthecloud/protosource"
 	"github.com/funinthecloud/protosource/opaquedata"
 	recordv1 "github.com/funinthecloud/protosource/record/v1"
 	"google.golang.org/protobuf/proto"
@@ -276,7 +278,15 @@ func (s *DynamoDBStore) SaveAggregate(ctx context.Context, aggregate proto.Messa
 	if !ok {
 		return fmt.Errorf("dynamodbstore.SaveAggregate: aggregate %T does not implement opaquedata.AutoPKSK", aggregate)
 	}
-	od, err := opaquedata.NewOpaqueDataFromProto(apk)
+	var opts []opaquedata.Option
+	if ttler, ok := aggregate.(protosource.EventTTLer); ok && ttler.EventTTLSeconds() > 0 {
+		ttlSec := ttler.EventTTLSeconds()
+		if ttlSec > math.MaxInt64/int64(time.Second) {
+			return fmt.Errorf("dynamodbstore.SaveAggregate: event_ttl_seconds %d overflows time.Duration", ttlSec)
+		}
+		opts = append(opts, opaquedata.WithTTL(time.Duration(ttlSec)*time.Second))
+	}
+	od, err := opaquedata.NewOpaqueDataFromProto(apk, opts...)
 	if err != nil {
 		return fmt.Errorf("dynamodbstore.SaveAggregate: opaquedata: %w", err)
 	}

--- a/stores/dynamodbstore/dynamodbstore_test.go
+++ b/stores/dynamodbstore/dynamodbstore_test.go
@@ -2,6 +2,7 @@ package dynamodbstore
 
 import (
 	"context"
+	"math"
 	"fmt"
 	"sort"
 	"strconv"
@@ -370,6 +371,48 @@ func TestSaveAggregate_WithOpaqueStore(t *testing.T) {
 	err = store.SaveAggregate(ctx, &testv1.Test{Id: "agg-1", Version: 5, Body: "state-data"})
 	require.NoError(t, err)
 	assert.Len(t, opaqueStore.items, 1)
+}
+
+func TestSaveAggregate_PropagatesTTL(t *testing.T) {
+	mock := newMockDynamoer()
+	opaqueStore := &mockOpaqueStore{}
+	store, err := New(mock, WithOpaqueStore(opaqueStore))
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	agg := &testv1.Test{Id: "agg-1", Version: 1, Body: "data"}
+	ttl := time.Duration(agg.EventTTLSeconds()) * time.Second
+	before := time.Now().Add(ttl).Unix()
+	err = store.SaveAggregate(ctx, agg)
+	after := time.Now().Add(ttl).Unix()
+	require.NoError(t, err)
+
+	require.Len(t, opaqueStore.items, 1)
+	for _, od := range opaqueStore.items {
+		assert.GreaterOrEqual(t, od.GetT(), before, "TTL should be at least now+86400s")
+		assert.LessOrEqual(t, od.GetT(), after, "TTL should be at most now+86400s")
+	}
+}
+
+// overflowTTLAggregate is a test-only aggregate that returns a TTL value
+// large enough to overflow time.Duration when multiplied by time.Second.
+type overflowTTLAggregate struct {
+	testv1.Test
+}
+
+func (o *overflowTTLAggregate) EventTTLSeconds() int64 { return math.MaxInt64 }
+
+func TestSaveAggregate_TTLOverflowReturnsError(t *testing.T) {
+	mock := newMockDynamoer()
+	opaqueStore := &mockOpaqueStore{}
+	store, err := New(mock, WithOpaqueStore(opaqueStore))
+	require.NoError(t, err)
+
+	err = store.SaveAggregate(context.Background(), &overflowTTLAggregate{
+		Test: testv1.Test{Id: "agg-1", Version: 1},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "overflows time.Duration")
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- When an aggregate has `event_ttl_seconds` set (via proto annotation), the TTL was correctly stamped on event records but **not** on the materialized aggregate row in the aggregates table
- `SaveAggregate` now checks if the aggregate implements `protosource.EventTTLer` and passes `opaquedata.WithTTL(...)` to `NewOpaqueDataFromProto`, so the DynamoDB `t` attribute is set on materialized rows
- No wire infrastructure changes — the fix is a type assertion inside `SaveAggregate` using the existing `EventTTLer` interface

## Test plan

- [x] Added `TestSaveAggregate_PropagatesTTL` verifying the `t` field is set to ~now+86400s for `testv1.Test` (which has `event_ttl_seconds: 86400`)
- [x] All existing tests pass (`go test ./...`)