### PR TITLE
Switch plugin publishing to buf beta registry plugin push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,21 +16,7 @@ jobs:
           setup_only: true
           token: ${{ secrets.BUF_TOKEN }}
 
-      # Push proto module to BSR with version label
       - name: Push proto module
         env:
           BUF_TOKEN: ${{ secrets.BUF_TOKEN }}
         run: buf push --label ${GITHUB_REF_NAME}
-
-      # Build and push plugin images
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to BSR plugin registry
-        run: echo "${{ secrets.BUF_TOKEN }}" | docker login plugins.buf.build -u _ --password-stdin
-
-      - name: Build and push plugins
-        run: |
-          VERSION=${GITHUB_REF_NAME}
-          docker buildx build -f Dockerfile.protosource -t plugins.buf.build/funinthecloud/protosource:${VERSION} --platform linux/amd64 --push .
-          docker buildx build -f Dockerfile.protosource-ts -t plugins.buf.build/funinthecloud/protosource-ts:${VERSION} --platform linux/amd64 --push .

--- a/Dockerfile.protosource
+++ b/Dockerfile.protosource
@@ -6,6 +6,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /protoc-gen-protosource ./cmd/protoc-gen-protosource
 
 FROM scratch
+COPY --from=build /etc/passwd /etc/passwd
 COPY --from=build /protoc-gen-protosource /
-USER 65532:65532
+USER nobody
 ENTRYPOINT ["/protoc-gen-protosource"]

--- a/Dockerfile.protosource-ts
+++ b/Dockerfile.protosource-ts
@@ -6,6 +6,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /protoc-gen-protosource-ts ./cmd/protoc-gen-protosource-ts
 
 FROM scratch
+COPY --from=build /etc/passwd /etc/passwd
 COPY --from=build /protoc-gen-protosource-ts /
-USER 65532:65532
+USER nobody
 ENTRYPOINT ["/protoc-gen-protosource-ts"]


### PR DESCRIPTION
## Summary
- Replace `docker login` + `docker buildx --push` workflow with `buf beta registry plugin push`
- Add `buf.plugin.yaml` and `buf.plugin.ts.yaml` with plugin metadata (version injected at CI time from git tag)
- Update Dockerfiles to use `USER nobody` and copy `/etc/passwd` from builder (required by buf for `scratch` images)

## Test plan
- [ ] Tag a release and verify `buf beta registry plugin push` succeeds for both plugins
- [ ] Confirm plugins appear at `buf.build/funinthecloud/protoc-gen-protosource` and `buf.build/funinthecloud/protoc-gen-protosource-ts`