### PR TITLE
fix(release): upgrade to Node 24 for npm OIDC publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,4 +46,4 @@ jobs:
         run: |
           npm ci
           npm run build
-          npm publish --access public
+          npm publish


### PR DESCRIPTION
## Summary

- Upgrade `actions/setup-node` from Node 20 to Node 24 to resolve npm OIDC publishing issues

## Test plan

- [ ] Tag a release and verify npm publish succeeds with OIDC auth