### PR TITLE
feat(authz): add Authorizer interface wired into generated handlers

### DIFF
--- a/authz/allowall/allowall.go
+++ b/authz/allowall/allowall.go
@@ -1,0 +1,43 @@
+// Package allowall provides a no-op [authz.Authorizer] that permits every
+// request.
+//
+// It is the framework default binding for [authz.Authorizer] and is
+// appropriate for local development, unit tests, and services that enforce
+// authorization at a different layer (for example, an upstream gateway).
+//
+// Never include this in a production wire set unless you are certain that
+// authorization is handled elsewhere.
+package allowall
+
+import (
+	"context"
+
+	"github.com/goforj/wire"
+
+	"github.com/funinthecloud/protosource"
+	"github.com/funinthecloud/protosource/authz"
+)
+
+// Authorizer is a no-op implementation of [authz.Authorizer] that permits
+// every request and returns the incoming context unchanged.
+type Authorizer struct{}
+
+// Authorize always returns the incoming context unchanged and a nil error.
+func (Authorizer) Authorize(ctx context.Context, _ protosource.Request, _ string) (context.Context, error) {
+	return ctx, nil
+}
+
+// Compile-time assertion that Authorizer satisfies [authz.Authorizer].
+var _ authz.Authorizer = Authorizer{}
+
+// Provide returns a no-op Authorizer bound to the [authz.Authorizer]
+// interface. This is the wire provider used by [ProviderSet].
+func Provide() authz.Authorizer {
+	return Authorizer{}
+}
+
+// ProviderSet wires the no-op allow-all Authorizer as [authz.Authorizer].
+// Include this set in a wire.Build call to get default allow-all semantics.
+// Production deployments should provide their own Authorizer binding
+// instead of including this set.
+var ProviderSet = wire.NewSet(Provide)

--- a/authz/authorizer.go
+++ b/authz/authorizer.go
@@ -1,0 +1,101 @@
+// Package authz defines the Authorizer contract that every generated command
+// handler invokes before its pipeline runs.
+//
+// The protosource plugin stamps a canonical function name ({proto_package}.
+// {CommandMessageName}, e.g. "example.app.sample.v1.Create") into each
+// generated handler at code-generation time. At request time the handler
+// calls Authorizer.Authorize with that name, letting the implementation
+// decide whether the caller is allowed to proceed.
+//
+// The framework ships [allowall.Authorizer] as the default binding so that
+// generated code compiles and runs out of the box with no real authorization
+// wired up. Production deployments override that binding with a concrete
+// implementation — for example, the shadow-token authorizer published by the
+// protosource-auth project.
+package authz
+
+import (
+	"context"
+	"errors"
+
+	"github.com/funinthecloud/protosource"
+)
+
+// Authorizer gates every generated command handler.
+//
+// Implementations inspect the incoming request (cookies, authorization
+// header, etc.) to determine the caller's identity, verify that the caller
+// holds requiredFunction, and optionally enrich the returned context with
+// identity facts ([WithUserID], [WithJWT]) that downstream handler code can
+// read.
+//
+// The requiredFunction argument is the canonical function name for the
+// command being invoked. By convention it is "{proto_package}.{MessageName}"
+// (e.g. "example.app.sample.v1.Create"). The protosource plugin generates
+// this string at compile time — callers never construct it.
+//
+// Error semantics mapped by generated handlers:
+//
+//   - Returning [ErrUnauthenticated] yields HTTP 401.
+//   - Returning [ErrForbidden] yields HTTP 403.
+//   - Any other non-nil error is treated as [ErrForbidden] for conservative
+//     safety — implementations should wrap their internal errors in one of
+//     the typed sentinels above when they want a specific status code.
+//
+// Implementations should be safe for concurrent use.
+type Authorizer interface {
+	Authorize(ctx context.Context, request protosource.Request, requiredFunction string) (context.Context, error)
+}
+
+// ErrUnauthenticated indicates that the caller could not be identified —
+// missing, expired, or malformed credentials. Generated handlers map this
+// to HTTP 401.
+var ErrUnauthenticated = errors.New("authz: unauthenticated")
+
+// ErrForbidden indicates that the caller was identified but does not hold
+// the required function. Generated handlers map this to HTTP 403.
+var ErrForbidden = errors.New("authz: forbidden")
+
+// ── Context helpers ──
+//
+// Authorizer implementations use these helpers to stash resolved identity
+// facts into the context they return, and downstream application code reads
+// them back. The framework itself never inspects these values — they are a
+// convenience for handler authors.
+
+type ctxKey int
+
+const (
+	ctxKeyUserID ctxKey = iota
+	ctxKeyJWT
+)
+
+// WithUserID returns a child context carrying the authenticated user id.
+func WithUserID(ctx context.Context, userID string) context.Context {
+	return context.WithValue(ctx, ctxKeyUserID, userID)
+}
+
+// UserIDFromContext returns the user id stashed by an Authorizer via
+// [WithUserID], or "" if none is present.
+func UserIDFromContext(ctx context.Context) string {
+	if v, ok := ctx.Value(ctxKeyUserID).(string); ok {
+		return v
+	}
+	return ""
+}
+
+// WithJWT returns a child context carrying a forwarded JWT. Shadow-token
+// authorizers that dereference opaque tokens to real JWTs use this so
+// downstream handlers can reuse the JWT for outbound service calls.
+func WithJWT(ctx context.Context, jwt string) context.Context {
+	return context.WithValue(ctx, ctxKeyJWT, jwt)
+}
+
+// JWTFromContext returns the JWT stashed by an Authorizer via [WithJWT], or
+// "" if none is present.
+func JWTFromContext(ctx context.Context) string {
+	if v, ok := ctx.Value(ctxKeyJWT).(string); ok {
+		return v
+	}
+	return ""
+}

--- a/authz/authorizer_test.go
+++ b/authz/authorizer_test.go
@@ -1,0 +1,59 @@
+package authz_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/funinthecloud/protosource"
+	"github.com/funinthecloud/protosource/authz"
+	"github.com/funinthecloud/protosource/authz/allowall"
+)
+
+func TestAllowAllPermitsEveryRequest(t *testing.T) {
+	var a authz.Authorizer = allowall.Authorizer{}
+
+	ctx := context.Background()
+	req := protosource.Request{Actor: "anyone"}
+
+	gotCtx, err := a.Authorize(ctx, req, "example.v1.AnyCommand")
+	if err != nil {
+		t.Fatalf("allowall.Authorize returned error: %v", err)
+	}
+	if gotCtx != ctx {
+		t.Errorf("allowall.Authorize returned a different context; expected pass-through")
+	}
+}
+
+func TestUserIDContextRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	if got := authz.UserIDFromContext(ctx); got != "" {
+		t.Errorf("UserIDFromContext on empty context = %q, want empty", got)
+	}
+
+	ctx = authz.WithUserID(ctx, "user-42")
+	if got := authz.UserIDFromContext(ctx); got != "user-42" {
+		t.Errorf("UserIDFromContext = %q, want %q", got, "user-42")
+	}
+}
+
+func TestJWTContextRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	if got := authz.JWTFromContext(ctx); got != "" {
+		t.Errorf("JWTFromContext on empty context = %q, want empty", got)
+	}
+
+	ctx = authz.WithJWT(ctx, "eyJraWQiOi4uLg")
+	if got := authz.JWTFromContext(ctx); got != "eyJraWQiOi4uLg" {
+		t.Errorf("JWTFromContext = %q, want %q", got, "eyJraWQiOi4uLg")
+	}
+}
+
+func TestTypedErrorsAreDistinct(t *testing.T) {
+	if errors.Is(authz.ErrUnauthenticated, authz.ErrForbidden) {
+		t.Errorf("ErrUnauthenticated and ErrForbidden must not be equivalent")
+	}
+	if errors.Is(authz.ErrForbidden, authz.ErrUnauthenticated) {
+		t.Errorf("ErrForbidden and ErrUnauthenticated must not be equivalent")
+	}
+}

--- a/authz/handler_integration_test.go
+++ b/authz/handler_integration_test.go
@@ -1,0 +1,129 @@
+package authz_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/funinthecloud/protosource"
+	"github.com/funinthecloud/protosource/authz"
+	samplev1 "github.com/funinthecloud/protosource/example/app/sample/v1"
+)
+
+// fakeAuthorizer is a test double for authz.Authorizer that records the
+// arguments it was called with and returns a configured error.
+type fakeAuthorizer struct {
+	// returnErr is the error Authorize returns. If nil, Authorize succeeds.
+	returnErr error
+	// enrichCtx, when non-nil, is applied to the returned context.
+	enrichCtx func(context.Context) context.Context
+
+	// Captured call state:
+	calls                int
+	lastRequiredFunction string
+	lastRequest          protosource.Request
+}
+
+func (f *fakeAuthorizer) Authorize(ctx context.Context, req protosource.Request, requiredFunction string) (context.Context, error) {
+	f.calls++
+	f.lastRequiredFunction = requiredFunction
+	f.lastRequest = req
+	if f.returnErr != nil {
+		return ctx, f.returnErr
+	}
+	if f.enrichCtx != nil {
+		ctx = f.enrichCtx(ctx)
+	}
+	return ctx, nil
+}
+
+// newTestHandler constructs a samplev1.Handler with nil repo/client. This is
+// only safe when the test paths do not reach Repository.Apply or client
+// methods — i.e., tests that observe the authz layer's short-circuit
+// behavior before any pipeline work begins.
+func newTestHandler(a authz.Authorizer) *samplev1.Handler {
+	return samplev1.NewHandler(nil, nil, a)
+}
+
+func TestGeneratedHandlerCallsAuthorizeWithCanonicalFunctionName(t *testing.T) {
+	fake := &fakeAuthorizer{returnErr: authz.ErrForbidden}
+	h := newTestHandler(fake)
+
+	_ = h.HandleCreate(context.Background(), protosource.Request{Actor: "someone"})
+
+	if fake.calls != 1 {
+		t.Fatalf("authorizer called %d times, want 1", fake.calls)
+	}
+	const want = "example.app.sample.v1.Create"
+	if fake.lastRequiredFunction != want {
+		t.Errorf("requiredFunction = %q, want %q", fake.lastRequiredFunction, want)
+	}
+}
+
+func TestGeneratedHandlerMapsUnauthenticatedTo401(t *testing.T) {
+	h := newTestHandler(&fakeAuthorizer{returnErr: authz.ErrUnauthenticated})
+
+	resp := h.HandleCreate(context.Background(), protosource.Request{Actor: "someone"})
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("StatusCode = %d, want %d", resp.StatusCode, http.StatusUnauthorized)
+	}
+}
+
+func TestGeneratedHandlerMapsForbiddenTo403(t *testing.T) {
+	h := newTestHandler(&fakeAuthorizer{returnErr: authz.ErrForbidden})
+
+	resp := h.HandleCreate(context.Background(), protosource.Request{Actor: "someone"})
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("StatusCode = %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+}
+
+func TestGeneratedHandlerMapsUnknownErrorsToForbidden(t *testing.T) {
+	// Conservative default: unknown errors from the Authorizer are treated
+	// as forbidden, not 500 — failing closed is safer than failing open.
+	custom := errors.New("custom policy engine exploded")
+	h := newTestHandler(&fakeAuthorizer{returnErr: custom})
+
+	resp := h.HandleCreate(context.Background(), protosource.Request{Actor: "someone"})
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("StatusCode = %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+}
+
+func TestGeneratedHandlerShortCircuitsBeforePipeline(t *testing.T) {
+	// If authz fails, the handler must return without touching repo or
+	// attempting to unmarshal. We prove this indirectly by passing nil
+	// repo/client/body — if the handler tried to touch any of them it
+	// would panic.
+	h := newTestHandler(&fakeAuthorizer{returnErr: authz.ErrForbidden})
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("handler panicked after authz failure: %v", r)
+		}
+	}()
+
+	// No Actor, no Body, nil repo/client — only safe because authz fails first.
+	_ = h.HandleCreate(context.Background(), protosource.Request{})
+}
+
+func TestGeneratedHandlerPassesAuthzThenChecksActor(t *testing.T) {
+	// With a passing authz and empty Actor, the handler proceeds past
+	// Authorize and hits the CMD_NO_ACTOR check, returning 401. This
+	// confirms the authz call is non-blocking when it returns nil.
+	fake := &fakeAuthorizer{returnErr: nil}
+	h := newTestHandler(fake)
+
+	resp := h.HandleCreate(context.Background(), protosource.Request{Actor: ""})
+
+	if fake.calls != 1 {
+		t.Errorf("authorizer called %d times, want 1", fake.calls)
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("StatusCode = %d, want %d (CMD_NO_ACTOR after authz pass-through)", resp.StatusCode, http.StatusUnauthorized)
+	}
+}

--- a/authz/handler_integration_test.go
+++ b/authz/handler_integration_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/funinthecloud/protosource"
@@ -109,6 +110,26 @@ func TestGeneratedHandlerShortCircuitsBeforePipeline(t *testing.T) {
 
 	// No Actor, no Body, nil repo/client — only safe because authz fails first.
 	_ = h.HandleCreate(context.Background(), protosource.Request{})
+}
+
+func TestGeneratedNewHandlerPanicsOnNilAuthorizer(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("NewHandler(nil authorizer) did not panic")
+		}
+		msg, ok := r.(string)
+		if !ok {
+			t.Fatalf("panic value = %T %v, want string", r, r)
+		}
+		// Must name the package, the constructor, and point to the fix.
+		for _, want := range []string{"samplev1.NewHandler", "authorizer", "allowall"} {
+			if !strings.Contains(msg, want) {
+				t.Errorf("panic message %q missing %q", msg, want)
+			}
+		}
+	}()
+	_ = samplev1.NewHandler(nil, nil, nil)
 }
 
 func TestGeneratedHandlerPassesAuthzThenChecksActor(t *testing.T) {

--- a/cmd/protoc-gen-protosource/content/lambda.gotext
+++ b/cmd/protoc-gen-protosource/content/lambda.gotext
@@ -13,6 +13,7 @@ import (
     "strings"
 
     "github.com/funinthecloud/protosource"
+    "github.com/funinthecloud/protosource/authz"
     "github.com/funinthecloud/protosource/opaquedata"
     responsev1 "github.com/funinthecloud/protosource/response/v1"
     "google.golang.org/protobuf/encoding/protojson"
@@ -35,13 +36,18 @@ type Repo interface {
 
 // Handler provides request handler functions for the {{ $aggregate }} aggregate.
 type Handler struct {
-    repo   Repo
-    client *{{ $aggregate }}Client
+    repo       Repo
+    client     *{{ $aggregate }}Client
+    authorizer authz.Authorizer
 }
 
-// NewHandler creates a new Handler instance with the given repository and client.
-func NewHandler(repo Repo, client *{{ $aggregate }}Client) *Handler {
-    return &Handler{repo: repo, client: client}
+// NewHandler creates a new Handler instance with the given repository, client,
+// and authorizer. Every generated command handler calls authorizer.Authorize
+// with the canonical function name "{{ protoPackage $ }}.{CommandMessageName}"
+// before running the command pipeline. Applications that do not enforce
+// authorization at this layer should wire in allowall.Authorizer.
+func NewHandler(repo Repo, client *{{ $aggregate }}Client, authorizer authz.Authorizer) *Handler {
+    return &Handler{repo: repo, client: client, authorizer: authorizer}
 }
 
 // RegisterRoutes registers all handler routes on the given router.
@@ -61,6 +67,11 @@ func (h *Handler) RegisterRoutes(router *protosource.Router) {
 {{ if isCommand $message }}
 // Handle{{ $message.Name }} processes a {{ $message.Name }} command.
 func (h *Handler) Handle{{ $message.Name }}(ctx context.Context, request protosource.Request) protosource.Response {
+    ctx, err := h.authorizer.Authorize(ctx, request, "{{ protoPackage $ }}.{{ $message.Name }}")
+    if err != nil {
+        return authzErrorResponse(err)
+    }
+
     if request.Actor == "" {
         return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
     }
@@ -363,6 +374,23 @@ func errorResponse(statusCode int, code, message string, cause error) protosourc
         StatusCode: statusCode,
         Body:       string(b),
         Headers:    map[string]string{"Content-Type": "application/json"},
+    }
+}
+
+// authzErrorResponse maps an authz.Authorizer error to an HTTP response.
+// ErrUnauthenticated yields 401; ErrForbidden yields 403. Any other error is
+// treated as forbidden for conservative safety — implementations should wrap
+// their internal errors in one of the typed sentinels when they want a
+// specific status code. Error details are intentionally not leaked to the
+// response body.
+func authzErrorResponse(err error) protosource.Response {
+    switch {
+    case errors.Is(err, authz.ErrUnauthenticated):
+        return errorResponse(http.StatusUnauthorized, "AUTHZ_UNAUTHENTICATED", "unauthenticated", nil)
+    case errors.Is(err, authz.ErrForbidden):
+        return errorResponse(http.StatusForbidden, "AUTHZ_FORBIDDEN", "forbidden", nil)
+    default:
+        return errorResponse(http.StatusForbidden, "AUTHZ_ERROR", "authorization failed", nil)
     }
 }
 

--- a/cmd/protoc-gen-protosource/content/lambda.gotext
+++ b/cmd/protoc-gen-protosource/content/lambda.gotext
@@ -46,7 +46,14 @@ type Handler struct {
 // with the canonical function name "{{ protoPackage $ }}.{CommandMessageName}"
 // before running the command pipeline. Applications that do not enforce
 // authorization at this layer should wire in allowall.Authorizer.
+//
+// authorizer is required; passing nil panics immediately with a descriptive
+// message rather than deferring to an opaque nil-pointer dereference on the
+// first request.
 func NewHandler(repo Repo, client *{{ $aggregate }}Client, authorizer authz.Authorizer) *Handler {
+    if authorizer == nil {
+        panic("{{ package . }}.NewHandler: authorizer must not be nil (use allowall.Authorizer{} for no enforcement)")
+    }
     return &Handler{repo: repo, client: client, authorizer: authorizer}
 }
 

--- a/cmd/protoc-gen-protosource/protosourceify.go
+++ b/cmd/protoc-gen-protosource/protosourceify.go
@@ -84,6 +84,7 @@ func (p *ProtosourceModule) templateFuncs() template.FuncMap {
 		"projectionsForFile":         p.projectionsForFile,
 		"aggregateForFile":           p.aggregateForFile,
 		"routePrefix":                p.routePrefix,
+		"protoPackage":               p.protoPackage,
 		"lower":                  strings.ToLower,
 		"importPath":             p.importPath,
 		"cliCommandFields":       CLICommandFields,
@@ -1054,6 +1055,14 @@ func (p *ProtosourceModule) routePrefix(f pgs.File) string {
 		return strings.TrimPrefix(rel, "/")
 	}
 	return importPath
+}
+
+// protoPackage returns the proto package name declared in a proto file
+// (e.g., "example.app.sample.v1"). Used by the lambda template to stamp the
+// canonical function name "{proto_package}.{CommandMessageName}" into each
+// generated handler's authz.Authorize call.
+func (p *ProtosourceModule) protoPackage(f pgs.File) string {
+	return f.Package().ProtoName().String()
 }
 
 func (p *ProtosourceModule) dump(input any) string {

--- a/cmd/testdynamo/wire.go
+++ b/cmd/testdynamo/wire.go
@@ -7,6 +7,7 @@ import (
 	"github.com/goforj/wire"
 
 	"github.com/funinthecloud/protosource"
+	"github.com/funinthecloud/protosource/authz/allowall"
 	"github.com/funinthecloud/protosource/aws/dynamoclient"
 	orderv1 "github.com/funinthecloud/protosource/example/app/order/v1"
 	orderv1dynamodb "github.com/funinthecloud/protosource/example/app/order/v1/orderv1dynamodb"
@@ -39,6 +40,7 @@ func InitializeRouter(
 		wire.Bind(new(opaquedata.OpaqueStore), new(*opaquedynamo.Store)),
 		dynamodbstore.ProviderSet,
 		protobinaryserializer.ProviderSet,
+		allowall.ProviderSet,
 		testv1dynamodb.ProviderSet,
 		orderv1dynamodb.ProviderSet,
 		samplev1dynamodb.ProviderSet,

--- a/cmd/testdynamo/wire_gen.go
+++ b/cmd/testdynamo/wire_gen.go
@@ -9,6 +9,7 @@ package main
 import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/funinthecloud/protosource"
+	"github.com/funinthecloud/protosource/authz/allowall"
 	"github.com/funinthecloud/protosource/example/app/order/v1"
 	"github.com/funinthecloud/protosource/example/app/order/v1/orderv1dynamodb"
 	"github.com/funinthecloud/protosource/example/app/sample/v1"
@@ -31,13 +32,14 @@ func InitializeRouter(client *dynamodb.Client, eventsTable dynamodbstore.EventsT
 	serializer := protobinaryserializer.NewSerializer()
 	repository := testv1dynamodb.ProvideRepository(dynamoDBStore, serializer)
 	testClient := testv1.NewTestClient(store)
-	handler := testv1.NewHandler(repository, testClient)
+	authorizer := allowall.Provide()
+	handler := testv1.NewHandler(repository, testClient, authorizer)
 	orderv1dynamodbRepository := orderv1dynamodb.ProvideRepository(dynamoDBStore, serializer)
 	orderClient := orderv1.NewOrderClient(store)
-	orderv1Handler := orderv1.NewHandler(orderv1dynamodbRepository, orderClient)
+	orderv1Handler := orderv1.NewHandler(orderv1dynamodbRepository, orderClient, authorizer)
 	samplev1dynamodbRepository := samplev1dynamodb.ProvideRepository(dynamoDBStore, serializer)
 	sampleClient := samplev1.NewSampleClient(store)
-	samplev1Handler := samplev1.NewHandler(samplev1dynamodbRepository, sampleClient)
+	samplev1Handler := samplev1.NewHandler(samplev1dynamodbRepository, sampleClient, authorizer)
 	router := provideRouter(handler, orderv1Handler, samplev1Handler)
 	return router, nil
 }

--- a/example/app/order/v1/order_v1.protosource.lambda.pb.go
+++ b/example/app/order/v1/order_v1.protosource.lambda.pb.go
@@ -38,7 +38,14 @@ type Handler struct {
 // with the canonical function name "example.app.order.v1.{CommandMessageName}"
 // before running the command pipeline. Applications that do not enforce
 // authorization at this layer should wire in allowall.Authorizer.
+//
+// authorizer is required; passing nil panics immediately with a descriptive
+// message rather than deferring to an opaque nil-pointer dereference on the
+// first request.
 func NewHandler(repo Repo, client *OrderClient, authorizer authz.Authorizer) *Handler {
+	if authorizer == nil {
+		panic("orderv1.NewHandler: authorizer must not be nil (use allowall.Authorizer{} for no enforcement)")
+	}
 	return &Handler{repo: repo, client: client, authorizer: authorizer}
 }
 

--- a/example/app/order/v1/order_v1.protosource.lambda.pb.go
+++ b/example/app/order/v1/order_v1.protosource.lambda.pb.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/funinthecloud/protosource"
+	"github.com/funinthecloud/protosource/authz"
 	"github.com/funinthecloud/protosource/opaquedata"
 	responsev1 "github.com/funinthecloud/protosource/response/v1"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -27,13 +28,18 @@ type Repo interface {
 
 // Handler provides request handler functions for the Order aggregate.
 type Handler struct {
-	repo   Repo
-	client *OrderClient
+	repo       Repo
+	client     *OrderClient
+	authorizer authz.Authorizer
 }
 
-// NewHandler creates a new Handler instance with the given repository and client.
-func NewHandler(repo Repo, client *OrderClient) *Handler {
-	return &Handler{repo: repo, client: client}
+// NewHandler creates a new Handler instance with the given repository, client,
+// and authorizer. Every generated command handler calls authorizer.Authorize
+// with the canonical function name "example.app.order.v1.{CommandMessageName}"
+// before running the command pipeline. Applications that do not enforce
+// authorization at this layer should wire in allowall.Authorizer.
+func NewHandler(repo Repo, client *OrderClient, authorizer authz.Authorizer) *Handler {
+	return &Handler{repo: repo, client: client, authorizer: authorizer}
 }
 
 // RegisterRoutes registers all handler routes on the given router.
@@ -65,6 +71,11 @@ func (h *Handler) RegisterRoutes(router *protosource.Router) {
 
 // HandleCreate processes a Create command.
 func (h *Handler) HandleCreate(ctx context.Context, request protosource.Request) protosource.Response {
+	ctx, err := h.authorizer.Authorize(ctx, request, "example.app.order.v1.Create")
+	if err != nil {
+		return authzErrorResponse(err)
+	}
+
 	if request.Actor == "" {
 		return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
 	}
@@ -96,6 +107,11 @@ func (h *Handler) HandleCreate(ctx context.Context, request protosource.Request)
 
 // HandleAddItem processes a AddItem command.
 func (h *Handler) HandleAddItem(ctx context.Context, request protosource.Request) protosource.Response {
+	ctx, err := h.authorizer.Authorize(ctx, request, "example.app.order.v1.AddItem")
+	if err != nil {
+		return authzErrorResponse(err)
+	}
+
 	if request.Actor == "" {
 		return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
 	}
@@ -127,6 +143,11 @@ func (h *Handler) HandleAddItem(ctx context.Context, request protosource.Request
 
 // HandleRemoveItem processes a RemoveItem command.
 func (h *Handler) HandleRemoveItem(ctx context.Context, request protosource.Request) protosource.Response {
+	ctx, err := h.authorizer.Authorize(ctx, request, "example.app.order.v1.RemoveItem")
+	if err != nil {
+		return authzErrorResponse(err)
+	}
+
 	if request.Actor == "" {
 		return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
 	}
@@ -158,6 +179,11 @@ func (h *Handler) HandleRemoveItem(ctx context.Context, request protosource.Requ
 
 // HandleAddTag processes a AddTag command.
 func (h *Handler) HandleAddTag(ctx context.Context, request protosource.Request) protosource.Response {
+	ctx, err := h.authorizer.Authorize(ctx, request, "example.app.order.v1.AddTag")
+	if err != nil {
+		return authzErrorResponse(err)
+	}
+
 	if request.Actor == "" {
 		return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
 	}
@@ -189,6 +215,11 @@ func (h *Handler) HandleAddTag(ctx context.Context, request protosource.Request)
 
 // HandleRemoveTag processes a RemoveTag command.
 func (h *Handler) HandleRemoveTag(ctx context.Context, request protosource.Request) protosource.Response {
+	ctx, err := h.authorizer.Authorize(ctx, request, "example.app.order.v1.RemoveTag")
+	if err != nil {
+		return authzErrorResponse(err)
+	}
+
 	if request.Actor == "" {
 		return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
 	}
@@ -220,6 +251,11 @@ func (h *Handler) HandleRemoveTag(ctx context.Context, request protosource.Reque
 
 // HandleSetShipping processes a SetShipping command.
 func (h *Handler) HandleSetShipping(ctx context.Context, request protosource.Request) protosource.Response {
+	ctx, err := h.authorizer.Authorize(ctx, request, "example.app.order.v1.SetShipping")
+	if err != nil {
+		return authzErrorResponse(err)
+	}
+
 	if request.Actor == "" {
 		return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
 	}
@@ -251,6 +287,11 @@ func (h *Handler) HandleSetShipping(ctx context.Context, request protosource.Req
 
 // HandlePlace processes a Place command.
 func (h *Handler) HandlePlace(ctx context.Context, request protosource.Request) protosource.Response {
+	ctx, err := h.authorizer.Authorize(ctx, request, "example.app.order.v1.Place")
+	if err != nil {
+		return authzErrorResponse(err)
+	}
+
 	if request.Actor == "" {
 		return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
 	}
@@ -282,6 +323,11 @@ func (h *Handler) HandlePlace(ctx context.Context, request protosource.Request) 
 
 // HandleCancel processes a Cancel command.
 func (h *Handler) HandleCancel(ctx context.Context, request protosource.Request) protosource.Response {
+	ctx, err := h.authorizer.Authorize(ctx, request, "example.app.order.v1.Cancel")
+	if err != nil {
+		return authzErrorResponse(err)
+	}
+
 	if request.Actor == "" {
 		return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
 	}
@@ -570,6 +616,23 @@ func errorResponse(statusCode int, code, message string, cause error) protosourc
 		StatusCode: statusCode,
 		Body:       string(b),
 		Headers:    map[string]string{"Content-Type": "application/json"},
+	}
+}
+
+// authzErrorResponse maps an authz.Authorizer error to an HTTP response.
+// ErrUnauthenticated yields 401; ErrForbidden yields 403. Any other error is
+// treated as forbidden for conservative safety — implementations should wrap
+// their internal errors in one of the typed sentinels when they want a
+// specific status code. Error details are intentionally not leaked to the
+// response body.
+func authzErrorResponse(err error) protosource.Response {
+	switch {
+	case errors.Is(err, authz.ErrUnauthenticated):
+		return errorResponse(http.StatusUnauthorized, "AUTHZ_UNAUTHENTICATED", "unauthenticated", nil)
+	case errors.Is(err, authz.ErrForbidden):
+		return errorResponse(http.StatusForbidden, "AUTHZ_FORBIDDEN", "forbidden", nil)
+	default:
+		return errorResponse(http.StatusForbidden, "AUTHZ_ERROR", "authorization failed", nil)
 	}
 }
 

--- a/example/app/sample/v1/sample_v1.protosource.lambda.pb.go
+++ b/example/app/sample/v1/sample_v1.protosource.lambda.pb.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/funinthecloud/protosource"
+	"github.com/funinthecloud/protosource/authz"
 	"github.com/funinthecloud/protosource/opaquedata"
 	responsev1 "github.com/funinthecloud/protosource/response/v1"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -27,13 +28,18 @@ type Repo interface {
 
 // Handler provides request handler functions for the Sample aggregate.
 type Handler struct {
-	repo   Repo
-	client *SampleClient
+	repo       Repo
+	client     *SampleClient
+	authorizer authz.Authorizer
 }
 
-// NewHandler creates a new Handler instance with the given repository and client.
-func NewHandler(repo Repo, client *SampleClient) *Handler {
-	return &Handler{repo: repo, client: client}
+// NewHandler creates a new Handler instance with the given repository, client,
+// and authorizer. Every generated command handler calls authorizer.Authorize
+// with the canonical function name "example.app.sample.v1.{CommandMessageName}"
+// before running the command pipeline. Applications that do not enforce
+// authorization at this layer should wire in allowall.Authorizer.
+func NewHandler(repo Repo, client *SampleClient, authorizer authz.Authorizer) *Handler {
+	return &Handler{repo: repo, client: client, authorizer: authorizer}
 }
 
 // RegisterRoutes registers all handler routes on the given router.
@@ -53,6 +59,11 @@ func (h *Handler) RegisterRoutes(router *protosource.Router) {
 
 // HandleCreate processes a Create command.
 func (h *Handler) HandleCreate(ctx context.Context, request protosource.Request) protosource.Response {
+	ctx, err := h.authorizer.Authorize(ctx, request, "example.app.sample.v1.Create")
+	if err != nil {
+		return authzErrorResponse(err)
+	}
+
 	if request.Actor == "" {
 		return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
 	}
@@ -84,6 +95,11 @@ func (h *Handler) HandleCreate(ctx context.Context, request protosource.Request)
 
 // HandleUpdate processes a Update command.
 func (h *Handler) HandleUpdate(ctx context.Context, request protosource.Request) protosource.Response {
+	ctx, err := h.authorizer.Authorize(ctx, request, "example.app.sample.v1.Update")
+	if err != nil {
+		return authzErrorResponse(err)
+	}
+
 	if request.Actor == "" {
 		return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
 	}
@@ -372,6 +388,23 @@ func errorResponse(statusCode int, code, message string, cause error) protosourc
 		StatusCode: statusCode,
 		Body:       string(b),
 		Headers:    map[string]string{"Content-Type": "application/json"},
+	}
+}
+
+// authzErrorResponse maps an authz.Authorizer error to an HTTP response.
+// ErrUnauthenticated yields 401; ErrForbidden yields 403. Any other error is
+// treated as forbidden for conservative safety — implementations should wrap
+// their internal errors in one of the typed sentinels when they want a
+// specific status code. Error details are intentionally not leaked to the
+// response body.
+func authzErrorResponse(err error) protosource.Response {
+	switch {
+	case errors.Is(err, authz.ErrUnauthenticated):
+		return errorResponse(http.StatusUnauthorized, "AUTHZ_UNAUTHENTICATED", "unauthenticated", nil)
+	case errors.Is(err, authz.ErrForbidden):
+		return errorResponse(http.StatusForbidden, "AUTHZ_FORBIDDEN", "forbidden", nil)
+	default:
+		return errorResponse(http.StatusForbidden, "AUTHZ_ERROR", "authorization failed", nil)
 	}
 }
 

--- a/example/app/sample/v1/sample_v1.protosource.lambda.pb.go
+++ b/example/app/sample/v1/sample_v1.protosource.lambda.pb.go
@@ -38,7 +38,14 @@ type Handler struct {
 // with the canonical function name "example.app.sample.v1.{CommandMessageName}"
 // before running the command pipeline. Applications that do not enforce
 // authorization at this layer should wire in allowall.Authorizer.
+//
+// authorizer is required; passing nil panics immediately with a descriptive
+// message rather than deferring to an opaque nil-pointer dereference on the
+// first request.
 func NewHandler(repo Repo, client *SampleClient, authorizer authz.Authorizer) *Handler {
+	if authorizer == nil {
+		panic("samplev1.NewHandler: authorizer must not be nil (use allowall.Authorizer{} for no enforcement)")
+	}
 	return &Handler{repo: repo, client: client, authorizer: authorizer}
 }
 

--- a/example/app/samplenosnapshot/v1/samplenosnapshot_v1.protosource.lambda.pb.go
+++ b/example/app/samplenosnapshot/v1/samplenosnapshot_v1.protosource.lambda.pb.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/funinthecloud/protosource"
+	"github.com/funinthecloud/protosource/authz"
 	"github.com/funinthecloud/protosource/opaquedata"
 	responsev1 "github.com/funinthecloud/protosource/response/v1"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -27,13 +28,18 @@ type Repo interface {
 
 // Handler provides request handler functions for the Sample aggregate.
 type Handler struct {
-	repo   Repo
-	client *SampleClient
+	repo       Repo
+	client     *SampleClient
+	authorizer authz.Authorizer
 }
 
-// NewHandler creates a new Handler instance with the given repository and client.
-func NewHandler(repo Repo, client *SampleClient) *Handler {
-	return &Handler{repo: repo, client: client}
+// NewHandler creates a new Handler instance with the given repository, client,
+// and authorizer. Every generated command handler calls authorizer.Authorize
+// with the canonical function name "example.app.samplenosnapshot.v1.{CommandMessageName}"
+// before running the command pipeline. Applications that do not enforce
+// authorization at this layer should wire in allowall.Authorizer.
+func NewHandler(repo Repo, client *SampleClient, authorizer authz.Authorizer) *Handler {
+	return &Handler{repo: repo, client: client, authorizer: authorizer}
 }
 
 // RegisterRoutes registers all handler routes on the given router.
@@ -51,6 +57,11 @@ func (h *Handler) RegisterRoutes(router *protosource.Router) {
 
 // HandleCreate processes a Create command.
 func (h *Handler) HandleCreate(ctx context.Context, request protosource.Request) protosource.Response {
+	ctx, err := h.authorizer.Authorize(ctx, request, "example.app.samplenosnapshot.v1.Create")
+	if err != nil {
+		return authzErrorResponse(err)
+	}
+
 	if request.Actor == "" {
 		return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
 	}
@@ -82,6 +93,11 @@ func (h *Handler) HandleCreate(ctx context.Context, request protosource.Request)
 
 // HandleUpdate processes a Update command.
 func (h *Handler) HandleUpdate(ctx context.Context, request protosource.Request) protosource.Response {
+	ctx, err := h.authorizer.Authorize(ctx, request, "example.app.samplenosnapshot.v1.Update")
+	if err != nil {
+		return authzErrorResponse(err)
+	}
+
 	if request.Actor == "" {
 		return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
 	}
@@ -304,6 +320,23 @@ func errorResponse(statusCode int, code, message string, cause error) protosourc
 		StatusCode: statusCode,
 		Body:       string(b),
 		Headers:    map[string]string{"Content-Type": "application/json"},
+	}
+}
+
+// authzErrorResponse maps an authz.Authorizer error to an HTTP response.
+// ErrUnauthenticated yields 401; ErrForbidden yields 403. Any other error is
+// treated as forbidden for conservative safety — implementations should wrap
+// their internal errors in one of the typed sentinels when they want a
+// specific status code. Error details are intentionally not leaked to the
+// response body.
+func authzErrorResponse(err error) protosource.Response {
+	switch {
+	case errors.Is(err, authz.ErrUnauthenticated):
+		return errorResponse(http.StatusUnauthorized, "AUTHZ_UNAUTHENTICATED", "unauthenticated", nil)
+	case errors.Is(err, authz.ErrForbidden):
+		return errorResponse(http.StatusForbidden, "AUTHZ_FORBIDDEN", "forbidden", nil)
+	default:
+		return errorResponse(http.StatusForbidden, "AUTHZ_ERROR", "authorization failed", nil)
 	}
 }
 

--- a/example/app/samplenosnapshot/v1/samplenosnapshot_v1.protosource.lambda.pb.go
+++ b/example/app/samplenosnapshot/v1/samplenosnapshot_v1.protosource.lambda.pb.go
@@ -38,7 +38,14 @@ type Handler struct {
 // with the canonical function name "example.app.samplenosnapshot.v1.{CommandMessageName}"
 // before running the command pipeline. Applications that do not enforce
 // authorization at this layer should wire in allowall.Authorizer.
+//
+// authorizer is required; passing nil panics immediately with a descriptive
+// message rather than deferring to an opaque nil-pointer dereference on the
+// first request.
 func NewHandler(repo Repo, client *SampleClient, authorizer authz.Authorizer) *Handler {
+	if authorizer == nil {
+		panic("samplenoprefixv1.NewHandler: authorizer must not be nil (use allowall.Authorizer{} for no enforcement)")
+	}
 	return &Handler{repo: repo, client: client, authorizer: authorizer}
 }
 

--- a/example/app/test/v1/test_v1.protosource.lambda.pb.go
+++ b/example/app/test/v1/test_v1.protosource.lambda.pb.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/funinthecloud/protosource"
+	"github.com/funinthecloud/protosource/authz"
 	"github.com/funinthecloud/protosource/opaquedata"
 	responsev1 "github.com/funinthecloud/protosource/response/v1"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -27,13 +28,18 @@ type Repo interface {
 
 // Handler provides request handler functions for the Test aggregate.
 type Handler struct {
-	repo   Repo
-	client *TestClient
+	repo       Repo
+	client     *TestClient
+	authorizer authz.Authorizer
 }
 
-// NewHandler creates a new Handler instance with the given repository and client.
-func NewHandler(repo Repo, client *TestClient) *Handler {
-	return &Handler{repo: repo, client: client}
+// NewHandler creates a new Handler instance with the given repository, client,
+// and authorizer. Every generated command handler calls authorizer.Authorize
+// with the canonical function name "example.app.test.v1.{CommandMessageName}"
+// before running the command pipeline. Applications that do not enforce
+// authorization at this layer should wire in allowall.Authorizer.
+func NewHandler(repo Repo, client *TestClient, authorizer authz.Authorizer) *Handler {
+	return &Handler{repo: repo, client: client, authorizer: authorizer}
 }
 
 // RegisterRoutes registers all handler routes on the given router.
@@ -60,6 +66,11 @@ func (h *Handler) RegisterRoutes(router *protosource.Router) {
 
 // HandleCreate processes a Create command.
 func (h *Handler) HandleCreate(ctx context.Context, request protosource.Request) protosource.Response {
+	ctx, err := h.authorizer.Authorize(ctx, request, "example.app.test.v1.Create")
+	if err != nil {
+		return authzErrorResponse(err)
+	}
+
 	if request.Actor == "" {
 		return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
 	}
@@ -91,6 +102,11 @@ func (h *Handler) HandleCreate(ctx context.Context, request protosource.Request)
 
 // HandleUpdate processes a Update command.
 func (h *Handler) HandleUpdate(ctx context.Context, request protosource.Request) protosource.Response {
+	ctx, err := h.authorizer.Authorize(ctx, request, "example.app.test.v1.Update")
+	if err != nil {
+		return authzErrorResponse(err)
+	}
+
 	if request.Actor == "" {
 		return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
 	}
@@ -122,6 +138,11 @@ func (h *Handler) HandleUpdate(ctx context.Context, request protosource.Request)
 
 // HandleLock processes a Lock command.
 func (h *Handler) HandleLock(ctx context.Context, request protosource.Request) protosource.Response {
+	ctx, err := h.authorizer.Authorize(ctx, request, "example.app.test.v1.Lock")
+	if err != nil {
+		return authzErrorResponse(err)
+	}
+
 	if request.Actor == "" {
 		return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
 	}
@@ -153,6 +174,11 @@ func (h *Handler) HandleLock(ctx context.Context, request protosource.Request) p
 
 // HandleUnlock processes a Unlock command.
 func (h *Handler) HandleUnlock(ctx context.Context, request protosource.Request) protosource.Response {
+	ctx, err := h.authorizer.Authorize(ctx, request, "example.app.test.v1.Unlock")
+	if err != nil {
+		return authzErrorResponse(err)
+	}
+
 	if request.Actor == "" {
 		return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
 	}
@@ -665,6 +691,23 @@ func errorResponse(statusCode int, code, message string, cause error) protosourc
 		StatusCode: statusCode,
 		Body:       string(b),
 		Headers:    map[string]string{"Content-Type": "application/json"},
+	}
+}
+
+// authzErrorResponse maps an authz.Authorizer error to an HTTP response.
+// ErrUnauthenticated yields 401; ErrForbidden yields 403. Any other error is
+// treated as forbidden for conservative safety — implementations should wrap
+// their internal errors in one of the typed sentinels when they want a
+// specific status code. Error details are intentionally not leaked to the
+// response body.
+func authzErrorResponse(err error) protosource.Response {
+	switch {
+	case errors.Is(err, authz.ErrUnauthenticated):
+		return errorResponse(http.StatusUnauthorized, "AUTHZ_UNAUTHENTICATED", "unauthenticated", nil)
+	case errors.Is(err, authz.ErrForbidden):
+		return errorResponse(http.StatusForbidden, "AUTHZ_FORBIDDEN", "forbidden", nil)
+	default:
+		return errorResponse(http.StatusForbidden, "AUTHZ_ERROR", "authorization failed", nil)
 	}
 }
 

--- a/example/app/test/v1/test_v1.protosource.lambda.pb.go
+++ b/example/app/test/v1/test_v1.protosource.lambda.pb.go
@@ -38,7 +38,14 @@ type Handler struct {
 // with the canonical function name "example.app.test.v1.{CommandMessageName}"
 // before running the command pipeline. Applications that do not enforce
 // authorization at this layer should wire in allowall.Authorizer.
+//
+// authorizer is required; passing nil panics immediately with a descriptive
+// message rather than deferring to an opaque nil-pointer dereference on the
+// first request.
 func NewHandler(repo Repo, client *TestClient, authorizer authz.Authorizer) *Handler {
+	if authorizer == nil {
+		panic("testv1.NewHandler: authorizer must not be nil (use allowall.Authorizer{} for no enforcement)")
+	}
 	return &Handler{repo: repo, client: client, authorizer: authorizer}
 }
 


### PR DESCRIPTION
## Summary

Phase 1 of the upcoming `protosource-auth` project. Establishes the framework-level authorization contract so a separate auth service can plug into any generated handler via wire, without any further codegen changes.

- New `authz` package with the `Authorizer` interface (`Authorize(ctx, req, requiredFunction) (ctx, error)`), typed `ErrUnauthenticated` / `ErrForbidden` errors, and `WithUserID` / `WithJWT` context helpers for downstream identity propagation.
- `authz/allowall` ships a no-op implementation and a `ProviderSet` — included in `wire.Build` it restores pre-PR behavior exactly.
- `protoc-gen-protosource` now stamps `h.authorizer.Authorize(ctx, request, "{proto_package}.{MessageName}")` into every generated command handler before the pipeline runs. New `authzErrorResponse` helper maps `ErrUnauthenticated` → 401, `ErrForbidden` → 403, unknown errors conservatively → 403.
- `NewHandler` gains an `authz.Authorizer` parameter; `cmd/testdynamo/wire.go` includes `allowall.ProviderSet` so behavior is unchanged.

Canonical function name is derived from the proto package plus the command message name (e.g. `example.app.sample.v1.Create`) — no annotations, no registry, no drift. A renamed command naturally invalidates existing role entries, which is the right failure mode.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — all 14 existing test packages pass unchanged
- [x] New `authz` package: 10 unit + integration tests covering allow-all pass-through, context round-trips, typed-error distinctness, canonical function name stamping, 401/403/conservative-403 mapping, pipeline short-circuit, and pass-through to the existing actor check