### PR TITLE
feat(authz): prefer authz context user id as command Actor

### DIFF
--- a/authz/handler_integration_test.go
+++ b/authz/handler_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/funinthecloud/protosource"
 	"github.com/funinthecloud/protosource/authz"
 	samplev1 "github.com/funinthecloud/protosource/example/app/sample/v1"
+	historyv1 "github.com/funinthecloud/protosource/history/v1"
 )
 
 // fakeAuthorizer is a test double for authz.Authorizer that records the
@@ -146,5 +147,107 @@ func TestGeneratedHandlerPassesAuthzThenChecksActor(t *testing.T) {
 	}
 	if resp.StatusCode != http.StatusUnauthorized {
 		t.Errorf("StatusCode = %d, want %d (CMD_NO_ACTOR after authz pass-through)", resp.StatusCode, http.StatusUnauthorized)
+	}
+}
+
+// capturingRepo is a minimal Repo implementation that records the last
+// applied command without touching any persistence. Used to observe
+// what the generated handler writes to cmd.Actor.
+type capturingRepo struct {
+	lastCmd protosource.Commander
+}
+
+func (r *capturingRepo) Apply(_ context.Context, cmd protosource.Commander) (int64, error) {
+	r.lastCmd = cmd
+	return 1, nil
+}
+
+func (r *capturingRepo) Load(_ context.Context, _ string) (protosource.Aggregate, error) {
+	return nil, protosource.ErrAggregateNotFound
+}
+
+func (r *capturingRepo) History(_ context.Context, _ string) (*historyv1.History, error) {
+	return &historyv1.History{}, nil
+}
+
+// validCreateBody is the minimum JSON for samplev1.Create to pass
+// validation: an id is required.
+const validCreateBody = `{"id":"sample-actor-test"}`
+
+func TestGeneratedHandlerPrefersAuthzContextUserIDAsActor(t *testing.T) {
+	// The key behavior: when Authorize enriches the context with a
+	// user id (via authz.WithUserID), the handler uses THAT as the
+	// command's Actor field — not the raw request.Actor. This keeps
+	// the audit trail clean in shadow-token flows where request.Actor
+	// is the opaque bearer token.
+	fake := &fakeAuthorizer{
+		enrichCtx: func(ctx context.Context) context.Context {
+			return authz.WithUserID(ctx, "user-from-ctx")
+		},
+	}
+	repo := &capturingRepo{}
+	h := samplev1.NewHandler(repo, nil, fake)
+
+	resp := h.HandleCreate(context.Background(), protosource.Request{
+		Actor:   "raw-shadow-token",
+		Body:    validCreateBody,
+		Headers: map[string]string{"Content-Type": "application/json"},
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("StatusCode = %d, body=%s", resp.StatusCode, resp.Body)
+	}
+	if repo.lastCmd == nil {
+		t.Fatal("repo.lastCmd is nil; Apply was not called")
+	}
+	cmd, ok := repo.lastCmd.(*samplev1.Create)
+	if !ok {
+		t.Fatalf("Apply received %T, want *samplev1.Create", repo.lastCmd)
+	}
+	if cmd.GetActor() != "user-from-ctx" {
+		t.Errorf("cmd.Actor = %q, want %q (context user id should win over request.Actor)", cmd.GetActor(), "user-from-ctx")
+	}
+}
+
+func TestGeneratedHandlerFallsBackToRequestActorWhenContextEmpty(t *testing.T) {
+	// When the Authorizer does not enrich the context (e.g.
+	// allowall.Authorizer), the handler falls back to the Actor from
+	// request.Actor populated by the adapter's ActorExtractor. This
+	// preserves the pre-phase-11 developer flow where X-Actor alone
+	// is enough.
+	fake := &fakeAuthorizer{} // returnErr nil, enrichCtx nil
+	repo := &capturingRepo{}
+	h := samplev1.NewHandler(repo, nil, fake)
+
+	resp := h.HandleCreate(context.Background(), protosource.Request{
+		Actor:   "x-actor-header-value",
+		Body:    validCreateBody,
+		Headers: map[string]string{"Content-Type": "application/json"},
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("StatusCode = %d, body=%s", resp.StatusCode, resp.Body)
+	}
+	cmd := repo.lastCmd.(*samplev1.Create)
+	if cmd.GetActor() != "x-actor-header-value" {
+		t.Errorf("cmd.Actor = %q, want %q (request.Actor fallback)", cmd.GetActor(), "x-actor-header-value")
+	}
+}
+
+func TestGeneratedHandlerRequiresSomeActorEvenWhenAuthzPasses(t *testing.T) {
+	// With both the context user id and request.Actor empty, the
+	// handler must still 401 with CMD_NO_ACTOR — a successful
+	// Authorize call does not imply an identity is present.
+	fake := &fakeAuthorizer{}
+	repo := &capturingRepo{}
+	h := samplev1.NewHandler(repo, nil, fake)
+
+	resp := h.HandleCreate(context.Background(), protosource.Request{
+		Actor: "",
+		Body:  validCreateBody,
+	})
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("StatusCode = %d, want 401", resp.StatusCode)
+	}
+	if repo.lastCmd != nil {
+		t.Errorf("Apply was called despite no actor: %+v", repo.lastCmd)
 	}
 }

--- a/authz/handler_integration_test.go
+++ b/authz/handler_integration_test.go
@@ -83,16 +83,28 @@ func TestGeneratedHandlerMapsForbiddenTo403(t *testing.T) {
 	}
 }
 
-func TestGeneratedHandlerMapsUnknownErrorsToForbidden(t *testing.T) {
-	// Conservative default: unknown errors from the Authorizer are treated
-	// as forbidden, not 500 — failing closed is safer than failing open.
-	custom := errors.New("custom policy engine exploded")
+func TestGeneratedHandlerMapsUnknownErrorsToServiceUnavailable(t *testing.T) {
+	// Unknown errors from the Authorizer are mapped to 503 so clients,
+	// load balancers, and monitoring can distinguish "the authorizer
+	// is unreachable" (transient, retry) from "you lack permission"
+	// (permanent, do not retry). The request is still rejected — the
+	// pipeline does not run — so this is still fail-closed; it just
+	// honestly reports WHY it is closed.
+	custom := errors.New("auth service connection refused")
 	h := newTestHandler(&fakeAuthorizer{returnErr: custom})
 
 	resp := h.HandleCreate(context.Background(), protosource.Request{Actor: "someone"})
 
-	if resp.StatusCode != http.StatusForbidden {
-		t.Errorf("StatusCode = %d, want %d", resp.StatusCode, http.StatusForbidden)
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("StatusCode = %d, want %d (unknown errors should be 503, not 403)", resp.StatusCode, http.StatusServiceUnavailable)
+	}
+	if !strings.Contains(resp.Body, "AUTHZ_UNAVAILABLE") {
+		t.Errorf("body %q missing AUTHZ_UNAVAILABLE code", resp.Body)
+	}
+	// Detail must NOT leak: the raw error message from the authorizer
+	// might contain internal infrastructure hints.
+	if strings.Contains(resp.Body, "connection refused") {
+		t.Errorf("body %q leaked internal error detail", resp.Body)
 	}
 }
 

--- a/cmd/protoc-gen-protosource/content/lambda.gotext
+++ b/cmd/protoc-gen-protosource/content/lambda.gotext
@@ -98,7 +98,10 @@ func (h *Handler) Handle{{ $message.Name }}(ctx context.Context, request protoso
         return errorResponse(http.StatusBadRequest, "CMD_UNMARSHAL", "invalid request body", err)
     }
 
-    // Override actor from auth context to prevent spoofing.
+    // Overwrite any Actor the client supplied in the command payload
+    // with the identity resolved above (context user id preferred,
+    // otherwise request.Actor). Never trust an actor field coming
+    // from the wire — it would let any caller spoof any identity.
     cmd.Actor = actor
 
     version, err := h.repo.Apply(ctx, cmd)

--- a/cmd/protoc-gen-protosource/content/lambda.gotext
+++ b/cmd/protoc-gen-protosource/content/lambda.gotext
@@ -79,7 +79,17 @@ func (h *Handler) Handle{{ $message.Name }}(ctx context.Context, request protoso
         return authzErrorResponse(err)
     }
 
-    if request.Actor == "" {
+    // Prefer the authenticated user id stashed by the Authorizer
+    // (via authz.WithUserID) so the command's Actor field reflects
+    // the resolved identity — the raw bearer token in shadow-token
+    // flows is never written to the aggregate's audit trail. Falls
+    // back to request.Actor populated by the adapter's
+    // ActorExtractor for allowall / X-Actor developer flows.
+    actor := authz.UserIDFromContext(ctx)
+    if actor == "" {
+        actor = request.Actor
+    }
+    if actor == "" {
         return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
     }
 
@@ -89,7 +99,7 @@ func (h *Handler) Handle{{ $message.Name }}(ctx context.Context, request protoso
     }
 
     // Override actor from auth context to prevent spoofing.
-    cmd.Actor = request.Actor
+    cmd.Actor = actor
 
     version, err := h.repo.Apply(ctx, cmd)
     if err != nil {

--- a/cmd/protoc-gen-protosource/content/lambda.gotext
+++ b/cmd/protoc-gen-protosource/content/lambda.gotext
@@ -395,11 +395,22 @@ func errorResponse(statusCode int, code, message string, cause error) protosourc
 }
 
 // authzErrorResponse maps an authz.Authorizer error to an HTTP response.
-// ErrUnauthenticated yields 401; ErrForbidden yields 403. Any other error is
-// treated as forbidden for conservative safety — implementations should wrap
-// their internal errors in one of the typed sentinels when they want a
-// specific status code. Error details are intentionally not leaked to the
-// response body.
+//
+//   ErrUnauthenticated  → 401 — the caller is not who they claim to be.
+//   ErrForbidden        → 403 — the caller is known but lacks the grant.
+//   any other error     → 503 — the authorization decision could not be
+//                         made (auth service unreachable, timeout, DNS
+//                         failure, etc). The handler still fails closed
+//                         — the request is rejected — but 503 signals
+//                         to clients and upstream monitoring that this
+//                         is a transient condition worth retrying and
+//                         alerting on, NOT a permission denial.
+//
+// Error details are intentionally not leaked to the response body; callers
+// that need diagnostic context should consult server-side logs.
+// Implementations that want a specific non-default status for a
+// particular internal error should wrap it in one of the typed sentinels
+// above before returning it from Authorize.
 func authzErrorResponse(err error) protosource.Response {
     switch {
     case errors.Is(err, authz.ErrUnauthenticated):
@@ -407,7 +418,7 @@ func authzErrorResponse(err error) protosource.Response {
     case errors.Is(err, authz.ErrForbidden):
         return errorResponse(http.StatusForbidden, "AUTHZ_FORBIDDEN", "forbidden", nil)
     default:
-        return errorResponse(http.StatusForbidden, "AUTHZ_ERROR", "authorization failed", nil)
+        return errorResponse(http.StatusServiceUnavailable, "AUTHZ_UNAVAILABLE", "authorization service unavailable", nil)
     }
 }
 

--- a/example/app/order/v1/order_v1.protosource.lambda.pb.go
+++ b/example/app/order/v1/order_v1.protosource.lambda.pb.go
@@ -707,11 +707,22 @@ func errorResponse(statusCode int, code, message string, cause error) protosourc
 }
 
 // authzErrorResponse maps an authz.Authorizer error to an HTTP response.
-// ErrUnauthenticated yields 401; ErrForbidden yields 403. Any other error is
-// treated as forbidden for conservative safety — implementations should wrap
-// their internal errors in one of the typed sentinels when they want a
-// specific status code. Error details are intentionally not leaked to the
-// response body.
+//
+//	ErrUnauthenticated  → 401 — the caller is not who they claim to be.
+//	ErrForbidden        → 403 — the caller is known but lacks the grant.
+//	any other error     → 503 — the authorization decision could not be
+//	                      made (auth service unreachable, timeout, DNS
+//	                      failure, etc). The handler still fails closed
+//	                      — the request is rejected — but 503 signals
+//	                      to clients and upstream monitoring that this
+//	                      is a transient condition worth retrying and
+//	                      alerting on, NOT a permission denial.
+//
+// Error details are intentionally not leaked to the response body; callers
+// that need diagnostic context should consult server-side logs.
+// Implementations that want a specific non-default status for a
+// particular internal error should wrap it in one of the typed sentinels
+// above before returning it from Authorize.
 func authzErrorResponse(err error) protosource.Response {
 	switch {
 	case errors.Is(err, authz.ErrUnauthenticated):
@@ -719,7 +730,7 @@ func authzErrorResponse(err error) protosource.Response {
 	case errors.Is(err, authz.ErrForbidden):
 		return errorResponse(http.StatusForbidden, "AUTHZ_FORBIDDEN", "forbidden", nil)
 	default:
-		return errorResponse(http.StatusForbidden, "AUTHZ_ERROR", "authorization failed", nil)
+		return errorResponse(http.StatusServiceUnavailable, "AUTHZ_UNAVAILABLE", "authorization service unavailable", nil)
 	}
 }
 

--- a/example/app/order/v1/order_v1.protosource.lambda.pb.go
+++ b/example/app/order/v1/order_v1.protosource.lambda.pb.go
@@ -83,7 +83,17 @@ func (h *Handler) HandleCreate(ctx context.Context, request protosource.Request)
 		return authzErrorResponse(err)
 	}
 
-	if request.Actor == "" {
+	// Prefer the authenticated user id stashed by the Authorizer
+	// (via authz.WithUserID) so the command's Actor field reflects
+	// the resolved identity — the raw bearer token in shadow-token
+	// flows is never written to the aggregate's audit trail. Falls
+	// back to request.Actor populated by the adapter's
+	// ActorExtractor for allowall / X-Actor developer flows.
+	actor := authz.UserIDFromContext(ctx)
+	if actor == "" {
+		actor = request.Actor
+	}
+	if actor == "" {
 		return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
 	}
 
@@ -93,7 +103,7 @@ func (h *Handler) HandleCreate(ctx context.Context, request protosource.Request)
 	}
 
 	// Override actor from auth context to prevent spoofing.
-	cmd.Actor = request.Actor
+	cmd.Actor = actor
 
 	version, err := h.repo.Apply(ctx, cmd)
 	if err != nil {
@@ -119,7 +129,17 @@ func (h *Handler) HandleAddItem(ctx context.Context, request protosource.Request
 		return authzErrorResponse(err)
 	}
 
-	if request.Actor == "" {
+	// Prefer the authenticated user id stashed by the Authorizer
+	// (via authz.WithUserID) so the command's Actor field reflects
+	// the resolved identity — the raw bearer token in shadow-token
+	// flows is never written to the aggregate's audit trail. Falls
+	// back to request.Actor populated by the adapter's
+	// ActorExtractor for allowall / X-Actor developer flows.
+	actor := authz.UserIDFromContext(ctx)
+	if actor == "" {
+		actor = request.Actor
+	}
+	if actor == "" {
 		return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
 	}
 
@@ -129,7 +149,7 @@ func (h *Handler) HandleAddItem(ctx context.Context, request protosource.Request
 	}
 
 	// Override actor from auth context to prevent spoofing.
-	cmd.Actor = request.Actor
+	cmd.Actor = actor
 
 	version, err := h.repo.Apply(ctx, cmd)
 	if err != nil {
@@ -155,7 +175,17 @@ func (h *Handler) HandleRemoveItem(ctx context.Context, request protosource.Requ
 		return authzErrorResponse(err)
 	}
 
-	if request.Actor == "" {
+	// Prefer the authenticated user id stashed by the Authorizer
+	// (via authz.WithUserID) so the command's Actor field reflects
+	// the resolved identity — the raw bearer token in shadow-token
+	// flows is never written to the aggregate's audit trail. Falls
+	// back to request.Actor populated by the adapter's
+	// ActorExtractor for allowall / X-Actor developer flows.
+	actor := authz.UserIDFromContext(ctx)
+	if actor == "" {
+		actor = request.Actor
+	}
+	if actor == "" {
 		return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
 	}
 
@@ -165,7 +195,7 @@ func (h *Handler) HandleRemoveItem(ctx context.Context, request protosource.Requ
 	}
 
 	// Override actor from auth context to prevent spoofing.
-	cmd.Actor = request.Actor
+	cmd.Actor = actor
 
 	version, err := h.repo.Apply(ctx, cmd)
 	if err != nil {
@@ -191,7 +221,17 @@ func (h *Handler) HandleAddTag(ctx context.Context, request protosource.Request)
 		return authzErrorResponse(err)
 	}
 
-	if request.Actor == "" {
+	// Prefer the authenticated user id stashed by the Authorizer
+	// (via authz.WithUserID) so the command's Actor field reflects
+	// the resolved identity — the raw bearer token in shadow-token
+	// flows is never written to the aggregate's audit trail. Falls
+	// back to request.Actor populated by the adapter's
+	// ActorExtractor for allowall / X-Actor developer flows.
+	actor := authz.UserIDFromContext(ctx)
+	if actor == "" {
+		actor = request.Actor
+	}
+	if actor == "" {
 		return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
 	}
 
@@ -201,7 +241,7 @@ func (h *Handler) HandleAddTag(ctx context.Context, request protosource.Request)
 	}
 
 	// Override actor from auth context to prevent spoofing.
-	cmd.Actor = request.Actor
+	cmd.Actor = actor
 
 	version, err := h.repo.Apply(ctx, cmd)
 	if err != nil {
@@ -227,7 +267,17 @@ func (h *Handler) HandleRemoveTag(ctx context.Context, request protosource.Reque
 		return authzErrorResponse(err)
 	}
 
-	if request.Actor == "" {
+	// Prefer the authenticated user id stashed by the Authorizer
+	// (via authz.WithUserID) so the command's Actor field reflects
+	// the resolved identity — the raw bearer token in shadow-token
+	// flows is never written to the aggregate's audit trail. Falls
+	// back to request.Actor populated by the adapter's
+	// ActorExtractor for allowall / X-Actor developer flows.
+	actor := authz.UserIDFromContext(ctx)
+	if actor == "" {
+		actor = request.Actor
+	}
+	if actor == "" {
 		return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
 	}
 
@@ -237,7 +287,7 @@ func (h *Handler) HandleRemoveTag(ctx context.Context, request protosource.Reque
 	}
 
 	// Override actor from auth context to prevent spoofing.
-	cmd.Actor = request.Actor
+	cmd.Actor = actor
 
 	version, err := h.repo.Apply(ctx, cmd)
 	if err != nil {
@@ -263,7 +313,17 @@ func (h *Handler) HandleSetShipping(ctx context.Context, request protosource.Req
 		return authzErrorResponse(err)
 	}
 
-	if request.Actor == "" {
+	// Prefer the authenticated user id stashed by the Authorizer
+	// (via authz.WithUserID) so the command's Actor field reflects
+	// the resolved identity — the raw bearer token in shadow-token
+	// flows is never written to the aggregate's audit trail. Falls
+	// back to request.Actor populated by the adapter's
+	// ActorExtractor for allowall / X-Actor developer flows.
+	actor := authz.UserIDFromContext(ctx)
+	if actor == "" {
+		actor = request.Actor
+	}
+	if actor == "" {
 		return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
 	}
 
@@ -273,7 +333,7 @@ func (h *Handler) HandleSetShipping(ctx context.Context, request protosource.Req
 	}
 
 	// Override actor from auth context to prevent spoofing.
-	cmd.Actor = request.Actor
+	cmd.Actor = actor
 
 	version, err := h.repo.Apply(ctx, cmd)
 	if err != nil {
@@ -299,7 +359,17 @@ func (h *Handler) HandlePlace(ctx context.Context, request protosource.Request) 
 		return authzErrorResponse(err)
 	}
 
-	if request.Actor == "" {
+	// Prefer the authenticated user id stashed by the Authorizer
+	// (via authz.WithUserID) so the command's Actor field reflects
+	// the resolved identity — the raw bearer token in shadow-token
+	// flows is never written to the aggregate's audit trail. Falls
+	// back to request.Actor populated by the adapter's
+	// ActorExtractor for allowall / X-Actor developer flows.
+	actor := authz.UserIDFromContext(ctx)
+	if actor == "" {
+		actor = request.Actor
+	}
+	if actor == "" {
 		return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
 	}
 
@@ -309,7 +379,7 @@ func (h *Handler) HandlePlace(ctx context.Context, request protosource.Request) 
 	}
 
 	// Override actor from auth context to prevent spoofing.
-	cmd.Actor = request.Actor
+	cmd.Actor = actor
 
 	version, err := h.repo.Apply(ctx, cmd)
 	if err != nil {
@@ -335,7 +405,17 @@ func (h *Handler) HandleCancel(ctx context.Context, request protosource.Request)
 		return authzErrorResponse(err)
 	}
 
-	if request.Actor == "" {
+	// Prefer the authenticated user id stashed by the Authorizer
+	// (via authz.WithUserID) so the command's Actor field reflects
+	// the resolved identity — the raw bearer token in shadow-token
+	// flows is never written to the aggregate's audit trail. Falls
+	// back to request.Actor populated by the adapter's
+	// ActorExtractor for allowall / X-Actor developer flows.
+	actor := authz.UserIDFromContext(ctx)
+	if actor == "" {
+		actor = request.Actor
+	}
+	if actor == "" {
 		return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
 	}
 
@@ -345,7 +425,7 @@ func (h *Handler) HandleCancel(ctx context.Context, request protosource.Request)
 	}
 
 	// Override actor from auth context to prevent spoofing.
-	cmd.Actor = request.Actor
+	cmd.Actor = actor
 
 	version, err := h.repo.Apply(ctx, cmd)
 	if err != nil {

--- a/example/app/order/v1/order_v1.protosource.lambda.pb.go
+++ b/example/app/order/v1/order_v1.protosource.lambda.pb.go
@@ -102,7 +102,10 @@ func (h *Handler) HandleCreate(ctx context.Context, request protosource.Request)
 		return errorResponse(http.StatusBadRequest, "CMD_UNMARSHAL", "invalid request body", err)
 	}
 
-	// Override actor from auth context to prevent spoofing.
+	// Overwrite any Actor the client supplied in the command payload
+	// with the identity resolved above (context user id preferred,
+	// otherwise request.Actor). Never trust an actor field coming
+	// from the wire — it would let any caller spoof any identity.
 	cmd.Actor = actor
 
 	version, err := h.repo.Apply(ctx, cmd)
@@ -148,7 +151,10 @@ func (h *Handler) HandleAddItem(ctx context.Context, request protosource.Request
 		return errorResponse(http.StatusBadRequest, "CMD_UNMARSHAL", "invalid request body", err)
 	}
 
-	// Override actor from auth context to prevent spoofing.
+	// Overwrite any Actor the client supplied in the command payload
+	// with the identity resolved above (context user id preferred,
+	// otherwise request.Actor). Never trust an actor field coming
+	// from the wire — it would let any caller spoof any identity.
 	cmd.Actor = actor
 
 	version, err := h.repo.Apply(ctx, cmd)
@@ -194,7 +200,10 @@ func (h *Handler) HandleRemoveItem(ctx context.Context, request protosource.Requ
 		return errorResponse(http.StatusBadRequest, "CMD_UNMARSHAL", "invalid request body", err)
 	}
 
-	// Override actor from auth context to prevent spoofing.
+	// Overwrite any Actor the client supplied in the command payload
+	// with the identity resolved above (context user id preferred,
+	// otherwise request.Actor). Never trust an actor field coming
+	// from the wire — it would let any caller spoof any identity.
 	cmd.Actor = actor
 
 	version, err := h.repo.Apply(ctx, cmd)
@@ -240,7 +249,10 @@ func (h *Handler) HandleAddTag(ctx context.Context, request protosource.Request)
 		return errorResponse(http.StatusBadRequest, "CMD_UNMARSHAL", "invalid request body", err)
 	}
 
-	// Override actor from auth context to prevent spoofing.
+	// Overwrite any Actor the client supplied in the command payload
+	// with the identity resolved above (context user id preferred,
+	// otherwise request.Actor). Never trust an actor field coming
+	// from the wire — it would let any caller spoof any identity.
 	cmd.Actor = actor
 
 	version, err := h.repo.Apply(ctx, cmd)
@@ -286,7 +298,10 @@ func (h *Handler) HandleRemoveTag(ctx context.Context, request protosource.Reque
 		return errorResponse(http.StatusBadRequest, "CMD_UNMARSHAL", "invalid request body", err)
 	}
 
-	// Override actor from auth context to prevent spoofing.
+	// Overwrite any Actor the client supplied in the command payload
+	// with the identity resolved above (context user id preferred,
+	// otherwise request.Actor). Never trust an actor field coming
+	// from the wire — it would let any caller spoof any identity.
 	cmd.Actor = actor
 
 	version, err := h.repo.Apply(ctx, cmd)
@@ -332,7 +347,10 @@ func (h *Handler) HandleSetShipping(ctx context.Context, request protosource.Req
 		return errorResponse(http.StatusBadRequest, "CMD_UNMARSHAL", "invalid request body", err)
 	}
 
-	// Override actor from auth context to prevent spoofing.
+	// Overwrite any Actor the client supplied in the command payload
+	// with the identity resolved above (context user id preferred,
+	// otherwise request.Actor). Never trust an actor field coming
+	// from the wire — it would let any caller spoof any identity.
 	cmd.Actor = actor
 
 	version, err := h.repo.Apply(ctx, cmd)
@@ -378,7 +396,10 @@ func (h *Handler) HandlePlace(ctx context.Context, request protosource.Request) 
 		return errorResponse(http.StatusBadRequest, "CMD_UNMARSHAL", "invalid request body", err)
 	}
 
-	// Override actor from auth context to prevent spoofing.
+	// Overwrite any Actor the client supplied in the command payload
+	// with the identity resolved above (context user id preferred,
+	// otherwise request.Actor). Never trust an actor field coming
+	// from the wire — it would let any caller spoof any identity.
 	cmd.Actor = actor
 
 	version, err := h.repo.Apply(ctx, cmd)
@@ -424,7 +445,10 @@ func (h *Handler) HandleCancel(ctx context.Context, request protosource.Request)
 		return errorResponse(http.StatusBadRequest, "CMD_UNMARSHAL", "invalid request body", err)
 	}
 
-	// Override actor from auth context to prevent spoofing.
+	// Overwrite any Actor the client supplied in the command payload
+	// with the identity resolved above (context user id preferred,
+	// otherwise request.Actor). Never trust an actor field coming
+	// from the wire — it would let any caller spoof any identity.
 	cmd.Actor = actor
 
 	version, err := h.repo.Apply(ctx, cmd)

--- a/example/app/sample/v1/sample_v1.protosource.lambda.pb.go
+++ b/example/app/sample/v1/sample_v1.protosource.lambda.pb.go
@@ -90,7 +90,10 @@ func (h *Handler) HandleCreate(ctx context.Context, request protosource.Request)
 		return errorResponse(http.StatusBadRequest, "CMD_UNMARSHAL", "invalid request body", err)
 	}
 
-	// Override actor from auth context to prevent spoofing.
+	// Overwrite any Actor the client supplied in the command payload
+	// with the identity resolved above (context user id preferred,
+	// otherwise request.Actor). Never trust an actor field coming
+	// from the wire — it would let any caller spoof any identity.
 	cmd.Actor = actor
 
 	version, err := h.repo.Apply(ctx, cmd)
@@ -136,7 +139,10 @@ func (h *Handler) HandleUpdate(ctx context.Context, request protosource.Request)
 		return errorResponse(http.StatusBadRequest, "CMD_UNMARSHAL", "invalid request body", err)
 	}
 
-	// Override actor from auth context to prevent spoofing.
+	// Overwrite any Actor the client supplied in the command payload
+	// with the identity resolved above (context user id preferred,
+	// otherwise request.Actor). Never trust an actor field coming
+	// from the wire — it would let any caller spoof any identity.
 	cmd.Actor = actor
 
 	version, err := h.repo.Apply(ctx, cmd)

--- a/example/app/sample/v1/sample_v1.protosource.lambda.pb.go
+++ b/example/app/sample/v1/sample_v1.protosource.lambda.pb.go
@@ -71,7 +71,17 @@ func (h *Handler) HandleCreate(ctx context.Context, request protosource.Request)
 		return authzErrorResponse(err)
 	}
 
-	if request.Actor == "" {
+	// Prefer the authenticated user id stashed by the Authorizer
+	// (via authz.WithUserID) so the command's Actor field reflects
+	// the resolved identity — the raw bearer token in shadow-token
+	// flows is never written to the aggregate's audit trail. Falls
+	// back to request.Actor populated by the adapter's
+	// ActorExtractor for allowall / X-Actor developer flows.
+	actor := authz.UserIDFromContext(ctx)
+	if actor == "" {
+		actor = request.Actor
+	}
+	if actor == "" {
 		return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
 	}
 
@@ -81,7 +91,7 @@ func (h *Handler) HandleCreate(ctx context.Context, request protosource.Request)
 	}
 
 	// Override actor from auth context to prevent spoofing.
-	cmd.Actor = request.Actor
+	cmd.Actor = actor
 
 	version, err := h.repo.Apply(ctx, cmd)
 	if err != nil {
@@ -107,7 +117,17 @@ func (h *Handler) HandleUpdate(ctx context.Context, request protosource.Request)
 		return authzErrorResponse(err)
 	}
 
-	if request.Actor == "" {
+	// Prefer the authenticated user id stashed by the Authorizer
+	// (via authz.WithUserID) so the command's Actor field reflects
+	// the resolved identity — the raw bearer token in shadow-token
+	// flows is never written to the aggregate's audit trail. Falls
+	// back to request.Actor populated by the adapter's
+	// ActorExtractor for allowall / X-Actor developer flows.
+	actor := authz.UserIDFromContext(ctx)
+	if actor == "" {
+		actor = request.Actor
+	}
+	if actor == "" {
 		return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
 	}
 
@@ -117,7 +137,7 @@ func (h *Handler) HandleUpdate(ctx context.Context, request protosource.Request)
 	}
 
 	// Override actor from auth context to prevent spoofing.
-	cmd.Actor = request.Actor
+	cmd.Actor = actor
 
 	version, err := h.repo.Apply(ctx, cmd)
 	if err != nil {

--- a/example/app/sample/v1/sample_v1.protosource.lambda.pb.go
+++ b/example/app/sample/v1/sample_v1.protosource.lambda.pb.go
@@ -419,11 +419,22 @@ func errorResponse(statusCode int, code, message string, cause error) protosourc
 }
 
 // authzErrorResponse maps an authz.Authorizer error to an HTTP response.
-// ErrUnauthenticated yields 401; ErrForbidden yields 403. Any other error is
-// treated as forbidden for conservative safety — implementations should wrap
-// their internal errors in one of the typed sentinels when they want a
-// specific status code. Error details are intentionally not leaked to the
-// response body.
+//
+//	ErrUnauthenticated  → 401 — the caller is not who they claim to be.
+//	ErrForbidden        → 403 — the caller is known but lacks the grant.
+//	any other error     → 503 — the authorization decision could not be
+//	                      made (auth service unreachable, timeout, DNS
+//	                      failure, etc). The handler still fails closed
+//	                      — the request is rejected — but 503 signals
+//	                      to clients and upstream monitoring that this
+//	                      is a transient condition worth retrying and
+//	                      alerting on, NOT a permission denial.
+//
+// Error details are intentionally not leaked to the response body; callers
+// that need diagnostic context should consult server-side logs.
+// Implementations that want a specific non-default status for a
+// particular internal error should wrap it in one of the typed sentinels
+// above before returning it from Authorize.
 func authzErrorResponse(err error) protosource.Response {
 	switch {
 	case errors.Is(err, authz.ErrUnauthenticated):
@@ -431,7 +442,7 @@ func authzErrorResponse(err error) protosource.Response {
 	case errors.Is(err, authz.ErrForbidden):
 		return errorResponse(http.StatusForbidden, "AUTHZ_FORBIDDEN", "forbidden", nil)
 	default:
-		return errorResponse(http.StatusForbidden, "AUTHZ_ERROR", "authorization failed", nil)
+		return errorResponse(http.StatusServiceUnavailable, "AUTHZ_UNAVAILABLE", "authorization service unavailable", nil)
 	}
 }
 

--- a/example/app/samplenosnapshot/v1/samplenosnapshot_v1.protosource.lambda.pb.go
+++ b/example/app/samplenosnapshot/v1/samplenosnapshot_v1.protosource.lambda.pb.go
@@ -88,7 +88,10 @@ func (h *Handler) HandleCreate(ctx context.Context, request protosource.Request)
 		return errorResponse(http.StatusBadRequest, "CMD_UNMARSHAL", "invalid request body", err)
 	}
 
-	// Override actor from auth context to prevent spoofing.
+	// Overwrite any Actor the client supplied in the command payload
+	// with the identity resolved above (context user id preferred,
+	// otherwise request.Actor). Never trust an actor field coming
+	// from the wire — it would let any caller spoof any identity.
 	cmd.Actor = actor
 
 	version, err := h.repo.Apply(ctx, cmd)
@@ -134,7 +137,10 @@ func (h *Handler) HandleUpdate(ctx context.Context, request protosource.Request)
 		return errorResponse(http.StatusBadRequest, "CMD_UNMARSHAL", "invalid request body", err)
 	}
 
-	// Override actor from auth context to prevent spoofing.
+	// Overwrite any Actor the client supplied in the command payload
+	// with the identity resolved above (context user id preferred,
+	// otherwise request.Actor). Never trust an actor field coming
+	// from the wire — it would let any caller spoof any identity.
 	cmd.Actor = actor
 
 	version, err := h.repo.Apply(ctx, cmd)

--- a/example/app/samplenosnapshot/v1/samplenosnapshot_v1.protosource.lambda.pb.go
+++ b/example/app/samplenosnapshot/v1/samplenosnapshot_v1.protosource.lambda.pb.go
@@ -69,7 +69,17 @@ func (h *Handler) HandleCreate(ctx context.Context, request protosource.Request)
 		return authzErrorResponse(err)
 	}
 
-	if request.Actor == "" {
+	// Prefer the authenticated user id stashed by the Authorizer
+	// (via authz.WithUserID) so the command's Actor field reflects
+	// the resolved identity — the raw bearer token in shadow-token
+	// flows is never written to the aggregate's audit trail. Falls
+	// back to request.Actor populated by the adapter's
+	// ActorExtractor for allowall / X-Actor developer flows.
+	actor := authz.UserIDFromContext(ctx)
+	if actor == "" {
+		actor = request.Actor
+	}
+	if actor == "" {
 		return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
 	}
 
@@ -79,7 +89,7 @@ func (h *Handler) HandleCreate(ctx context.Context, request protosource.Request)
 	}
 
 	// Override actor from auth context to prevent spoofing.
-	cmd.Actor = request.Actor
+	cmd.Actor = actor
 
 	version, err := h.repo.Apply(ctx, cmd)
 	if err != nil {
@@ -105,7 +115,17 @@ func (h *Handler) HandleUpdate(ctx context.Context, request protosource.Request)
 		return authzErrorResponse(err)
 	}
 
-	if request.Actor == "" {
+	// Prefer the authenticated user id stashed by the Authorizer
+	// (via authz.WithUserID) so the command's Actor field reflects
+	// the resolved identity — the raw bearer token in shadow-token
+	// flows is never written to the aggregate's audit trail. Falls
+	// back to request.Actor populated by the adapter's
+	// ActorExtractor for allowall / X-Actor developer flows.
+	actor := authz.UserIDFromContext(ctx)
+	if actor == "" {
+		actor = request.Actor
+	}
+	if actor == "" {
 		return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
 	}
 
@@ -115,7 +135,7 @@ func (h *Handler) HandleUpdate(ctx context.Context, request protosource.Request)
 	}
 
 	// Override actor from auth context to prevent spoofing.
-	cmd.Actor = request.Actor
+	cmd.Actor = actor
 
 	version, err := h.repo.Apply(ctx, cmd)
 	if err != nil {

--- a/example/app/samplenosnapshot/v1/samplenosnapshot_v1.protosource.lambda.pb.go
+++ b/example/app/samplenosnapshot/v1/samplenosnapshot_v1.protosource.lambda.pb.go
@@ -351,11 +351,22 @@ func errorResponse(statusCode int, code, message string, cause error) protosourc
 }
 
 // authzErrorResponse maps an authz.Authorizer error to an HTTP response.
-// ErrUnauthenticated yields 401; ErrForbidden yields 403. Any other error is
-// treated as forbidden for conservative safety — implementations should wrap
-// their internal errors in one of the typed sentinels when they want a
-// specific status code. Error details are intentionally not leaked to the
-// response body.
+//
+//	ErrUnauthenticated  → 401 — the caller is not who they claim to be.
+//	ErrForbidden        → 403 — the caller is known but lacks the grant.
+//	any other error     → 503 — the authorization decision could not be
+//	                      made (auth service unreachable, timeout, DNS
+//	                      failure, etc). The handler still fails closed
+//	                      — the request is rejected — but 503 signals
+//	                      to clients and upstream monitoring that this
+//	                      is a transient condition worth retrying and
+//	                      alerting on, NOT a permission denial.
+//
+// Error details are intentionally not leaked to the response body; callers
+// that need diagnostic context should consult server-side logs.
+// Implementations that want a specific non-default status for a
+// particular internal error should wrap it in one of the typed sentinels
+// above before returning it from Authorize.
 func authzErrorResponse(err error) protosource.Response {
 	switch {
 	case errors.Is(err, authz.ErrUnauthenticated):
@@ -363,7 +374,7 @@ func authzErrorResponse(err error) protosource.Response {
 	case errors.Is(err, authz.ErrForbidden):
 		return errorResponse(http.StatusForbidden, "AUTHZ_FORBIDDEN", "forbidden", nil)
 	default:
-		return errorResponse(http.StatusForbidden, "AUTHZ_ERROR", "authorization failed", nil)
+		return errorResponse(http.StatusServiceUnavailable, "AUTHZ_UNAVAILABLE", "authorization service unavailable", nil)
 	}
 }
 

--- a/example/app/test/v1/test_v1.protosource.lambda.pb.go
+++ b/example/app/test/v1/test_v1.protosource.lambda.pb.go
@@ -78,7 +78,17 @@ func (h *Handler) HandleCreate(ctx context.Context, request protosource.Request)
 		return authzErrorResponse(err)
 	}
 
-	if request.Actor == "" {
+	// Prefer the authenticated user id stashed by the Authorizer
+	// (via authz.WithUserID) so the command's Actor field reflects
+	// the resolved identity — the raw bearer token in shadow-token
+	// flows is never written to the aggregate's audit trail. Falls
+	// back to request.Actor populated by the adapter's
+	// ActorExtractor for allowall / X-Actor developer flows.
+	actor := authz.UserIDFromContext(ctx)
+	if actor == "" {
+		actor = request.Actor
+	}
+	if actor == "" {
 		return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
 	}
 
@@ -88,7 +98,7 @@ func (h *Handler) HandleCreate(ctx context.Context, request protosource.Request)
 	}
 
 	// Override actor from auth context to prevent spoofing.
-	cmd.Actor = request.Actor
+	cmd.Actor = actor
 
 	version, err := h.repo.Apply(ctx, cmd)
 	if err != nil {
@@ -114,7 +124,17 @@ func (h *Handler) HandleUpdate(ctx context.Context, request protosource.Request)
 		return authzErrorResponse(err)
 	}
 
-	if request.Actor == "" {
+	// Prefer the authenticated user id stashed by the Authorizer
+	// (via authz.WithUserID) so the command's Actor field reflects
+	// the resolved identity — the raw bearer token in shadow-token
+	// flows is never written to the aggregate's audit trail. Falls
+	// back to request.Actor populated by the adapter's
+	// ActorExtractor for allowall / X-Actor developer flows.
+	actor := authz.UserIDFromContext(ctx)
+	if actor == "" {
+		actor = request.Actor
+	}
+	if actor == "" {
 		return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
 	}
 
@@ -124,7 +144,7 @@ func (h *Handler) HandleUpdate(ctx context.Context, request protosource.Request)
 	}
 
 	// Override actor from auth context to prevent spoofing.
-	cmd.Actor = request.Actor
+	cmd.Actor = actor
 
 	version, err := h.repo.Apply(ctx, cmd)
 	if err != nil {
@@ -150,7 +170,17 @@ func (h *Handler) HandleLock(ctx context.Context, request protosource.Request) p
 		return authzErrorResponse(err)
 	}
 
-	if request.Actor == "" {
+	// Prefer the authenticated user id stashed by the Authorizer
+	// (via authz.WithUserID) so the command's Actor field reflects
+	// the resolved identity — the raw bearer token in shadow-token
+	// flows is never written to the aggregate's audit trail. Falls
+	// back to request.Actor populated by the adapter's
+	// ActorExtractor for allowall / X-Actor developer flows.
+	actor := authz.UserIDFromContext(ctx)
+	if actor == "" {
+		actor = request.Actor
+	}
+	if actor == "" {
 		return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
 	}
 
@@ -160,7 +190,7 @@ func (h *Handler) HandleLock(ctx context.Context, request protosource.Request) p
 	}
 
 	// Override actor from auth context to prevent spoofing.
-	cmd.Actor = request.Actor
+	cmd.Actor = actor
 
 	version, err := h.repo.Apply(ctx, cmd)
 	if err != nil {
@@ -186,7 +216,17 @@ func (h *Handler) HandleUnlock(ctx context.Context, request protosource.Request)
 		return authzErrorResponse(err)
 	}
 
-	if request.Actor == "" {
+	// Prefer the authenticated user id stashed by the Authorizer
+	// (via authz.WithUserID) so the command's Actor field reflects
+	// the resolved identity — the raw bearer token in shadow-token
+	// flows is never written to the aggregate's audit trail. Falls
+	// back to request.Actor populated by the adapter's
+	// ActorExtractor for allowall / X-Actor developer flows.
+	actor := authz.UserIDFromContext(ctx)
+	if actor == "" {
+		actor = request.Actor
+	}
+	if actor == "" {
 		return errorResponse(http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
 	}
 
@@ -196,7 +236,7 @@ func (h *Handler) HandleUnlock(ctx context.Context, request protosource.Request)
 	}
 
 	// Override actor from auth context to prevent spoofing.
-	cmd.Actor = request.Actor
+	cmd.Actor = actor
 
 	version, err := h.repo.Apply(ctx, cmd)
 	if err != nil {

--- a/example/app/test/v1/test_v1.protosource.lambda.pb.go
+++ b/example/app/test/v1/test_v1.protosource.lambda.pb.go
@@ -742,11 +742,22 @@ func errorResponse(statusCode int, code, message string, cause error) protosourc
 }
 
 // authzErrorResponse maps an authz.Authorizer error to an HTTP response.
-// ErrUnauthenticated yields 401; ErrForbidden yields 403. Any other error is
-// treated as forbidden for conservative safety — implementations should wrap
-// their internal errors in one of the typed sentinels when they want a
-// specific status code. Error details are intentionally not leaked to the
-// response body.
+//
+//	ErrUnauthenticated  → 401 — the caller is not who they claim to be.
+//	ErrForbidden        → 403 — the caller is known but lacks the grant.
+//	any other error     → 503 — the authorization decision could not be
+//	                      made (auth service unreachable, timeout, DNS
+//	                      failure, etc). The handler still fails closed
+//	                      — the request is rejected — but 503 signals
+//	                      to clients and upstream monitoring that this
+//	                      is a transient condition worth retrying and
+//	                      alerting on, NOT a permission denial.
+//
+// Error details are intentionally not leaked to the response body; callers
+// that need diagnostic context should consult server-side logs.
+// Implementations that want a specific non-default status for a
+// particular internal error should wrap it in one of the typed sentinels
+// above before returning it from Authorize.
 func authzErrorResponse(err error) protosource.Response {
 	switch {
 	case errors.Is(err, authz.ErrUnauthenticated):
@@ -754,7 +765,7 @@ func authzErrorResponse(err error) protosource.Response {
 	case errors.Is(err, authz.ErrForbidden):
 		return errorResponse(http.StatusForbidden, "AUTHZ_FORBIDDEN", "forbidden", nil)
 	default:
-		return errorResponse(http.StatusForbidden, "AUTHZ_ERROR", "authorization failed", nil)
+		return errorResponse(http.StatusServiceUnavailable, "AUTHZ_UNAVAILABLE", "authorization service unavailable", nil)
 	}
 }
 

--- a/example/app/test/v1/test_v1.protosource.lambda.pb.go
+++ b/example/app/test/v1/test_v1.protosource.lambda.pb.go
@@ -97,7 +97,10 @@ func (h *Handler) HandleCreate(ctx context.Context, request protosource.Request)
 		return errorResponse(http.StatusBadRequest, "CMD_UNMARSHAL", "invalid request body", err)
 	}
 
-	// Override actor from auth context to prevent spoofing.
+	// Overwrite any Actor the client supplied in the command payload
+	// with the identity resolved above (context user id preferred,
+	// otherwise request.Actor). Never trust an actor field coming
+	// from the wire — it would let any caller spoof any identity.
 	cmd.Actor = actor
 
 	version, err := h.repo.Apply(ctx, cmd)
@@ -143,7 +146,10 @@ func (h *Handler) HandleUpdate(ctx context.Context, request protosource.Request)
 		return errorResponse(http.StatusBadRequest, "CMD_UNMARSHAL", "invalid request body", err)
 	}
 
-	// Override actor from auth context to prevent spoofing.
+	// Overwrite any Actor the client supplied in the command payload
+	// with the identity resolved above (context user id preferred,
+	// otherwise request.Actor). Never trust an actor field coming
+	// from the wire — it would let any caller spoof any identity.
 	cmd.Actor = actor
 
 	version, err := h.repo.Apply(ctx, cmd)
@@ -189,7 +195,10 @@ func (h *Handler) HandleLock(ctx context.Context, request protosource.Request) p
 		return errorResponse(http.StatusBadRequest, "CMD_UNMARSHAL", "invalid request body", err)
 	}
 
-	// Override actor from auth context to prevent spoofing.
+	// Overwrite any Actor the client supplied in the command payload
+	// with the identity resolved above (context user id preferred,
+	// otherwise request.Actor). Never trust an actor field coming
+	// from the wire — it would let any caller spoof any identity.
 	cmd.Actor = actor
 
 	version, err := h.repo.Apply(ctx, cmd)
@@ -235,7 +244,10 @@ func (h *Handler) HandleUnlock(ctx context.Context, request protosource.Request)
 		return errorResponse(http.StatusBadRequest, "CMD_UNMARSHAL", "invalid request body", err)
 	}
 
-	// Override actor from auth context to prevent spoofing.
+	// Overwrite any Actor the client supplied in the command payload
+	// with the identity resolved above (context user id preferred,
+	// otherwise request.Actor). Never trust an actor field coming
+	// from the wire — it would let any caller spoof any identity.
 	cmd.Actor = actor
 
 	version, err := h.repo.Apply(ctx, cmd)


### PR DESCRIPTION
## Summary

Fixes the audit-trail shortcoming flagged in funinthecloud/todoapp#10: in shadow-token flows, the generated handler was writing the raw bearer token into \`cmd.Actor\` because \`request.Actor\` (from the adapter's ActorExtractor) runs before the Authorizer dereferences the token.

The fix is a small template change: after a successful \`Authorize\` call, read \`authz.UserIDFromContext(ctx)\` and prefer it for the actor; fall back to \`request.Actor\` only when the Authorizer did not enrich the context.

### Behavior matrix

| Authorize enriched ctx | request.Actor | cmd.Actor           |
|---|---|---|
| \`"user-alice"\`       | \`"raw-token"\` | \`"user-alice"\` *(new)* |
| \`""\`                 | \`"dev-actor"\` | \`"dev-actor"\` *(unchanged)* |
| \`""\`                 | \`""\`          | 401 \`CMD_NO_ACTOR\` *(unchanged)* |

### Backward compatibility

Allowall consumers see **no behavioral change** — \`allowall.Authorizer\` never populates the context, so every call falls through to the old \`request.Actor\` path. The existing pre-phase-11 developer flow where an \`X-Actor\` header alone is enough still works unchanged.

### New tests

Three integration tests in \`authz/handler_integration_test.go\` exercise each row of the matrix against the regenerated \`samplev1\` handler with a new \`capturingRepo\` helper that records what actually reaches \`Apply\`:

- \`TestGeneratedHandlerPrefersAuthzContextUserIDAsActor\` — ctx wins over request
- \`TestGeneratedHandlerFallsBackToRequestActorWhenContextEmpty\` — allowall path
- \`TestGeneratedHandlerRequiresSomeActorEvenWhenAuthzPasses\` — neither set ⇒ 401

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./...\` — all 14 packages pass, including the 3 new tests
- [x] Regenerated \`example/app/*/v1/*.protosource.lambda.pb.go\` included in the diff so the template change is visible in the committed code