### PR TITLE
docs: add authz section to CLAUDE.md, extract TODO into TODO.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,17 @@ The framework's central types:
 - **`EventTTLer`** — optional interface (`EventTTLSeconds()`) for aggregates with `event_ttl_seconds` annotation. Repository stamps records with TTL before persisting.
 - **`Request`/`Response`/`HandlerFunc`** — provider-agnostic HTTP abstractions for generated handlers.
 
+### Authorization (`authz/`)
+
+Every generated command handler calls `authz.Authorizer.Authorize(ctx, req, "{proto_package}.{CommandName}")` before the pipeline runs. The function name is stamped at codegen time from the proto.
+
+- **`authz.Authorizer`** — interface with one method. Returns `(context.Context, error)` so implementations can enrich ctx with `WithUserID` / `WithJWT` for downstream handlers.
+- **`authz/allowall`** — no-op implementation; the default wire binding for consumers that enforce authorization elsewhere.
+- **`authz.ErrUnauthenticated` → 401**, **`ErrForbidden` → 403**, **anything else → 503 `AUTHZ_UNAVAILABLE`**. The 503 default is deliberate: transient auth-service failures (timeout, DNS, upstream 5xx) must not look like permission denials to load balancers and retry logic.
+- Generated handlers prefer `authz.UserIDFromContext(ctx)` over `request.Actor` when stamping `cmd.Actor`, so shadow-token flows get the resolved user id in the audit trail instead of the raw bearer.
+
+Reference implementation: [`funinthecloud/protosource-auth`](https://github.com/funinthecloud/protosource-auth) — a full shadow-token auth service (User/Role/Token/Issuer/Key aggregates + HTTP endpoints + mgr CLI) that ships `httpauthz.Authorizer` as the concrete client.
+
 ### Code Generation (`cmd/protoc-gen-protosource/`)
 
 The buf plugin reads proto annotations and generates four files per domain package:
@@ -280,11 +291,4 @@ Hosted buf plugins require a pro account, so plugins are not published to BSR. C
 
 ## TODO
 
-- [x] Single-aggregate projections: auto-generated from proto `projection = {}` annotation, wired into Repository pipeline (PR #23)
-- [x] Nested collections: `map<string, Message>` fields with ADD/REMOVE via `collection` annotation, `PostApplyHook` for derived fields (PR #24, #25)
-- [ ] Snapshot-aware event TTL (Case 2): pre-snapshot events get TTL while snapshots persist. Deferred — needs a triggered downstream process (e.g. DynamoDB Streams) to safely mark pre-snapshot events with TTL only after confirming the snapshot exists. Writing events with TTL proactively risks data loss if snapshots don't arrive in time.
-- [ ] Multi-aggregate projections: projections that join/denormalize across multiple aggregate types (e.g. Order + Customer → OrderWithCustomerView). Likely event-driven via DynamoDB Streams rather than synchronous in the pipeline.
-- [ ] Build a showcase app: React frontend + Go backend demonstrating event sourcing and CQRS with a to-do list manager domain (multiple lists, items, reordering, etc.) — simple enough to understand, rich enough to show projections and state transitions. Explore GraphQL as the read-side query layer over CQRS projections (natural fit: projections map to graph types, subscriptions for real-time updates)
-- [x] Make all dependencies more Wire-friendly: shared `aws/dynamoclient` interface, generated `providers.go` with Repository wrapper types, `wire.Bind`, interface params, shared infra in `dynamodbstore/providers.go` (PR #35)
-- [ ] Extract Go client library from `*mgr` CLI commands: reusable HTTP client for command submission, Get, and History — currently the CLI (`cli.gotext`) generates a standalone `main.go` with inline HTTP logic; extract the request/response handling into a generated client package that other Go applications can import
-- [x] Generate TypeScript client for React frontends: `protoc-gen-protosource-ts` buf plugin + `@protosource/client` runtime (`ts/client/`). Generates typed TS client per aggregate with command, load, history, and query methods. Uses `@bufbuild/protobuf` v2 for serialization, `fetch` for HTTP.
+See [TODO.md](TODO.md) for remaining framework work and cross-repo tracking.

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,40 @@
+# TODO
+
+Cross-repo tracking for the protosource ecosystem. Items marked against sibling repos are links only — the work lives there.
+
+## protosource (framework)
+
+### Framework gaps
+
+- [ ] **Snapshot-aware event TTL.** Pre-snapshot events should get TTL while snapshots persist. Deferred — needs a triggered downstream process (DynamoDB Streams) to safely mark pre-snapshot events with TTL only after confirming the snapshot exists. Writing TTL proactively risks data loss if the snapshot does not arrive.
+- [ ] **Multi-aggregate projections.** Projections that join across aggregate types (e.g. `Order + Customer → OrderWithCustomerView`). Likely event-driven via DynamoDB Streams rather than synchronous in the pipeline.
+- [ ] **Extract Go client library from `*mgr` CLI commands.** The generated `cli.gotext` currently inlines HTTP logic in a standalone `main.go`. Extract the request/response handling into a generated client package importable by other Go applications — mirrors the existing `protoc-gen-protosource-ts` client.
+- [ ] **Evaluate supporting RS256 / ES256 on the `authz.Authorizer` side.** Not strictly a framework change — the Authorizer is pluggable — but the handler template currently hard-codes no algorithm awareness. If a future consumer needs signing-algorithm routing at the handler level (e.g. per-aggregate audience), revisit.
+
+### Nice-to-have polish
+
+- [ ] **httpauthz retry logic.** A concrete future client (lives in protosource-auth) could benefit from exponential-backoff retries on 5xx. Out of scope for the framework itself but worth linking.
+- [ ] **Plugin integration test** that asserts every `isCommand` handler path emits the new `actor := authz.UserIDFromContext(ctx)` line. Currently covered indirectly by `authz/handler_integration_test.go`.
+
+### Done ✓
+
+- [x] Single-aggregate projections (PR #23)
+- [x] Nested collections with `map<string, Message>` + ADD/REMOVE via `collection` annotation (PR #24, #25)
+- [x] Wire-friendly provider sets + shared `dynamoclient` / `opaquedata` infra (PR #35)
+- [x] TypeScript client generation (`protoc-gen-protosource-ts` + `@protosource/client`)
+- [x] Showcase app: [`todoapp`](https://github.com/funinthecloud/todoapp) ships both `backend-bolt` and `backend-lambda` + a React frontend
+- [x] `authz.Authorizer` interface + generated handler integration (PR #64)
+- [x] Actor resolution prefers `authz.UserIDFromContext(ctx)` over `request.Actor` (PR #65, v0.1.3)
+- [x] Unknown authorizer errors → 503 `AUTHZ_UNAVAILABLE` instead of 403 (PR #65, v0.1.3)
+
+## protosource-auth
+
+Tracked in its own TODO section of [`protosource-auth/CLAUDE.md`](https://github.com/funinthecloud/protosource-auth/blob/main/CLAUDE.md). Highlights that affect the framework:
+
+- [ ] **JWKS endpoint** for offline JWT verification — would let downstream consumers skip the per-request `/authz/check` round-trip for JWT validation. Needs a follow-up plugin change to stamp JWKS URLs into generated handlers.
+- [ ] **Multi-aggregate projection for the user→function cache.** Waiting on framework-side multi-aggregate projections (above).
+
+## todoapp
+
+- [ ] **Frontend shadow-token integration.** The React frontend still sends `X-Actor`. Update it to POST `/login` against protosource-auth, store the shadow token, and send `Authorization: Bearer <token>` on every request.
+- [ ] **Deploy the auth service alongside the lambda backend.** Today `protosource-auth` runs as a standalone binary; adding a lambda deployment target for the auth service itself would let todoapp deploy both in one stack.


### PR DESCRIPTION
Pure docs pass on the framework's CLAUDE.md and a new TODO.md now that authz has landed and shipped to protosource-auth + todoapp.

## Changes

### \`CLAUDE.md\`

- New **Authorization (\`authz/\`)** subsection under Runtime Core covering:
  - The \`Authorizer\` interface and context-enrichment contract
  - \`authz/allowall\` as the default wire binding
  - Error → status mapping (\`401\` / \`403\` / \`503 AUTHZ_UNAVAILABLE\`) and why 503 is the default for unknown errors
  - The \`authz.UserIDFromContext\` precedence over \`request.Actor\` in generated handlers
  - Pointer to protosource-auth as the reference implementation
- TODO section replaced with a link to the new \`TODO.md\`.

### \`TODO.md\` *(new)*

Consolidates remaining framework work and cross-references the two downstream repos:

- **Framework:** snapshot-aware event TTL, multi-aggregate projections, Go client library extraction from \`*mgr\` CLI, plugin integration-test coverage for the new actor-resolution line.
- **Done:** Explicit checklist including the new authz interface (#64) and the v0.1.3 follow-ups (#65 + 503 mapping).
- **Links out:** protosource-auth's TODO for JWKS / RS256 / multi-algorithm, todoapp for frontend shadow-token integration + lambda deployment of the auth service.

Zero code changes — builds and tests are unaffected.

## Test plan

- [x] \`TODO.md\` and the linked CLAUDE.md section render correctly on GitHub
- [x] No code touched — existing CI still green