### PR TITLE
fix(ts-plugin): derive routePath from proto package

### DIFF
--- a/cmd/protoc-gen-protosource-ts/protosourceify.go
+++ b/cmd/protoc-gen-protosource-ts/protosourceify.go
@@ -180,13 +180,13 @@ func (p *ProtosourceModule) aggregateForFile(f pgs.File) pgs.Message {
 	return nil
 }
 
+// routePrefix returns the HTTP route prefix derived from the proto package
+// declaration (e.g. proto "auth.user.v1" → "auth/user/v1"). Deriving from the
+// proto package — rather than the Go import path — keeps the generated TS
+// client aligned with the server's registered routes regardless of how the
+// downstream consumer configures `module=` in buf.gen.ts.yaml.
 func (p *ProtosourceModule) routePrefix(f pgs.File) string {
-	importPath := p.ctx.ImportPath(f).String()
-	if mod := p.params.Str("module"); mod != "" {
-		rel := strings.TrimPrefix(importPath, mod)
-		return strings.TrimPrefix(rel, "/")
-	}
-	return importPath
+	return strings.ReplaceAll(f.Package().ProtoName().String(), ".", "/")
 }
 
 // clientCommandFields returns command fields excluding id and actor.

--- a/cmd/protoc-gen-protosource-ts/protosourceify_test.go
+++ b/cmd/protoc-gen-protosource-ts/protosourceify_test.go
@@ -96,6 +96,17 @@ func TestProtoFileNameFromBase(t *testing.T) {
 	}
 }
 
+func TestRoutePrefix(t *testing.T) {
+	f := loadTestProto(t, "gsi_enum.proto")
+	p := newModule()
+
+	got := p.routePrefix(f)
+	want := "test/gsi_enum"
+	if got != want {
+		t.Errorf("routePrefix() = %q, want %q (must derive from proto package, not Go import path)", got, want)
+	}
+}
+
 func TestGSIEnumTypes_EnumPK(t *testing.T) {
 	f := loadTestProto(t, "gsi_enum.proto")
 	p := newModule()

--- a/cmd/protoc-gen-protosource/protosourceify.go
+++ b/cmd/protoc-gen-protosource/protosourceify.go
@@ -1012,15 +1012,13 @@ func (p *ProtosourceModule) importPath(f pgs.File) string {
 	return p.ctx.ImportPath(f).String()
 }
 
-// routePrefix returns the module-stripped import path for a proto file,
-// used to derive HTTP route prefixes (e.g., "example/app/sample/v1").
+// routePrefix returns the HTTP route prefix derived from the proto package
+// declaration (e.g. proto "example.app.sample.v1" → "example/app/sample/v1").
+// Deriving from the proto package keeps server-registered routes and
+// generated client routes aligned regardless of the `module=` plugin param
+// or the proto's go_package option.
 func (p *ProtosourceModule) routePrefix(f pgs.File) string {
-	importPath := p.ctx.ImportPath(f).String()
-	if mod := p.params.Str("module"); mod != "" {
-		rel := strings.TrimPrefix(importPath, mod)
-		return strings.TrimPrefix(rel, "/")
-	}
-	return importPath
+	return strings.ReplaceAll(f.Package().ProtoName().String(), ".", "/")
 }
 
 // protoPackage returns the proto package name declared in a proto file

--- a/cmd/protoc-gen-protosource/protosourceify_test.go
+++ b/cmd/protoc-gen-protosource/protosourceify_test.go
@@ -70,6 +70,17 @@ func findMessage(f pgs.File, name string) pgs.Message {
 	return nil
 }
 
+func TestRoutePrefix(t *testing.T) {
+	f := loadTestProto(t, "valid.proto")
+	p := newModule()
+
+	got := p.routePrefix(f)
+	want := "test/valid"
+	if got != want {
+		t.Errorf("routePrefix() = %q, want %q (must derive from proto package, not Go import path)", got, want)
+	}
+}
+
 func TestBuildEnumValueIndex(t *testing.T) {
 	f := loadTestProto(t, "valid.proto")
 	idx := buildEnumValueIndex(f)


### PR DESCRIPTION
## Summary
- TS client generator's `routePath` now derives from the proto package declaration (dots → slashes) instead of stripping `module=` from the Go import path.
- Removes the dependency on plugin params: downstream consumers don't need to set `module=` in `buf.gen.ts.yaml` to get correct routes.
- Aligns TS-side `routePath` with what the Go-generated server actually registers via `router.Handle`.

## Why
Downstream consumers (e.g. `protosource-auth`) generated TS clients whose `routePath` was the full Go import path (`github.com/funinthecloud/protosource-auth/gen/auth/user/v1`), producing 404s against server routes registered at `auth/user/v1`. The Go client emitted the right value because the in-repo `buf.gen.yaml` happens to set `module=...`; the TS gen config in consumers typically doesn't.

## Test plan
- [x] `go test ./cmd/protoc-gen-protosource-ts/...` — new `TestRoutePrefix` asserts `test.gsi_enum` → `test/gsi_enum`.
- [x] `go test ./...` — all packages pass.
- [x] `go vet ./...` clean.
- [x] Regenerated in-repo TS clients (`buf generate --template buf.gen.ts.yaml`); `routePath` values unchanged for the example protos.
- [ ] Regenerate downstream `protosource-auth/frontend/src/gen/*.protosource.client.ts` after this lands; verify each emits `auth/<aggregate>/v1`.

## Follow-up
The Go plugin's `routePrefix` still uses the `module=`-stripped Go import path. Same end result today (since the server and Go client both consult that function), but worth aligning in a follow-up PR so the two plugins share identical logic.