### PR TITLE
generator: support singular embedded message events for aggregates (On emission) [protosource-5ww / GH#96]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,6 +270,44 @@ message ItemRemoved {
 - Commands with collection events carry the embedded message type (e.g., `LineItem item = 3`), parsed from JSON in the generated CLI
 - Multiple independent collections on one aggregate are supported (each with its own events)
 
+### Singular Embedded Message Fields
+
+For a singular (non-collection) embedded message on an aggregate — e.g. an `OidcConfig oidc = 8` field — there is **no annotation and no type inference**. The generated `On()` applies embedded message fields the same way it applies scalars: by **field name**. So the convention is simply to name the event's embedded field to match the aggregate's field.
+
+```protobuf
+message Account {
+  option (...).aggregate = {};
+  // ... contract fields ...
+  Profile profile = 8;            // singular embedded message
+}
+
+message Profile { string display_name = 1; string locale = 2; }
+
+// Set: carry a populated, same-named embed.
+message ProfileSet {
+  option (...).event = {};
+  // ... contract fields 1-4 ...
+  Profile profile = 5;            // name matches Account.profile
+}
+
+// Clear: carry the same-named embed left empty.
+message ProfileCleared {
+  option (...).event = {};
+  // ... contract fields 1-4 ...
+  Profile profile = 5;            // always empty -> nils the field
+}
+```
+
+**Generated On():**
+- Set: `aggregate.Profile = e.GetProfile()` — the populated message is copied in.
+- Clear: `aggregate.Profile = e.GetProfile()` — the empty message resolves to `nil`, clearing the field (the copy is unconditional).
+
+**Rules:**
+- The event's embedded field name **must match** the aggregate field name. Matching is by name, never by type.
+- A "set" event carries the populated message; a "clear" event carries the same-named field left empty.
+- If an event carries an embedded message of a type that exists on the aggregate but under a **different** name, codegen **fails** with a rename hint (otherwise the assignment would silently never happen — the original GH#96 failure mode). See `validateSingularEmbed` in `protosourceify.go`.
+- Two aggregate fields of the same message type are fine — they are distinguished by name (`SetOidc{Profile oidc}` vs `SetBackup{Profile backup}`).
+
 ### PostApplyHook (Derived Fields)
 
 For computed/derived fields (totals, counts, etc.), implement `AfterOn()` on the aggregate in a hand-written file:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -290,21 +290,21 @@ message ProfileSet {
   Profile profile = 5;            // name matches Account.profile
 }
 
-// Clear: carry the same-named embed left empty.
+// Clear: declare the same-named embed but emit it unset (nil).
 message ProfileCleared {
   option (...).event = {};
   // ... contract fields 1-4 ...
-  Profile profile = 5;            // always empty -> nils the field
+  Profile profile = 5;            // emitted unset (nil) -> nils the field
 }
 ```
 
 **Generated On():**
 - Set: `aggregate.Profile = e.GetProfile()` — the populated message is copied in.
-- Clear: `aggregate.Profile = e.GetProfile()` — the empty message resolves to `nil`, clearing the field (the copy is unconditional).
+- Clear: `aggregate.Profile = e.GetProfile()` — when the event field is **unset**, `GetProfile()` returns `nil`, clearing the field (the copy is unconditional). A clear command that carries no embed emits the field unset, so this just works. Note: a present-but-empty `&Profile{}` is **non-nil** and would **not** clear — clearing requires the field to be unset (nil).
 
 **Rules:**
 - The event's embedded field name **must match** the aggregate field name. Matching is by name, never by type.
-- A "set" event carries the populated message; a "clear" event carries the same-named field left empty.
+- A "set" event carries the populated message; a "clear" event leaves the same-named field **unset (nil)** — not present-but-empty.
 - If an event carries an embedded message of a type that exists on the aggregate but under a **different** name, codegen **fails** with a rename hint (otherwise the assignment would silently never happen — the original GH#96 failure mode). See `validateSingularEmbed` in `protosourceify.go`.
 - Two aggregate fields of the same message type are fine — they are distinguished by name (`SetOidc{Profile oidc}` vs `SetBackup{Profile backup}`).
 

--- a/cmd/protoc-gen-protosource/content/protosource.gotext
+++ b/cmd/protoc-gen-protosource/content/protosource.gotext
@@ -273,7 +273,7 @@ func (m *{{ $message.Name }}) EmitEvents(aggregate protosource.Aggregate) []prot
     {{ end -}}
     {{ range $eventName := commandEvents $message -}}
     {{ $evt := eventMessage $eventName $file -}}
-    b.{{ $eventName }}({{ range $field := $evt.Fields | excludeInternal }} m.Get{{ name $field }}(), {{ end }})
+    b.{{ $eventName }}({{ range $field := $evt.Fields | excludeInternal }} {{ commandEventArg $field $message }}, {{ end }})
     {{ if $hasSnapshot -}}
     _ = a.On(b.Events[len(b.Events)-1]) // safe: On only errors on unhandled event types, and we only emit events defined in this file
     b.Snapshot(a) // Snapshot calls AfterOn() internally only when a snapshot is actually emitted

--- a/cmd/protoc-gen-protosource/protosourceify.go
+++ b/cmd/protoc-gen-protosource/protosourceify.go
@@ -68,6 +68,7 @@ func (p *ProtosourceModule) templateFuncs() template.FuncMap {
 		"collectionKeyFieldGoName":   p.collectionKeyFieldGoName,
 		"aggregateFieldGoName":       p.aggregateFieldGoName,
 		"eventFieldGoName":           p.eventFieldGoName,
+		"commandEventArg":            p.commandEventArg,
 		"hasOpaqueAnnotations":       p.hasOpaqueAnnotations,
 		"opaqueKeyMappings":          p.opaqueKeyMappings,
 		"opaqueKeyPrefix":            p.opaqueKeyPrefix,
@@ -182,6 +183,32 @@ func (p *ProtosourceModule) aggregateHasField(eventField pgs.Field, aggregate pg
 		}
 	}
 	return false
+}
+
+// commandEventArg returns the Go expression passed to an event builder method
+// for eventField when emitting events from command cmd. If cmd has a field of
+// the same name, it is forwarded (m.GetX()); otherwise the field's zero value is
+// passed. The zero-value path supports "clear" events that carry an embedded
+// field the command intentionally omits — e.g. ClearBilling (no billing field)
+// emitting BillingCleared{billing: nil}, which On() copies to nil the field.
+func (p *ProtosourceModule) commandEventArg(eventField pgs.Field, cmd pgs.Message) string {
+	for _, f := range cmd.Fields() {
+		if f.Name() == eventField.Name() {
+			return "m.Get" + p.ctx.Name(eventField).String() + "()"
+		}
+	}
+	t := eventField.Type()
+	if t.IsRepeated() || t.IsMap() || t.IsEmbed() || t.ProtoType() == pgs.BytesT {
+		return "nil"
+	}
+	switch t.ProtoType() {
+	case pgs.StringT:
+		return `""`
+	case pgs.BoolT:
+		return "false"
+	default:
+		return "0" // numeric and enum (untyped 0 converts to the named type)
+	}
 }
 
 func (p *ProtosourceModule) messageOptions(m pgs.Message) *optionsv1.MessageOptions {
@@ -443,6 +470,9 @@ func isSingularEmbedField(f pgs.Field) bool {
 }
 
 // validateSingularEmbed enforces the singular embedded-message convention.
+//
+// DECISION: singular embeds are applied by field name (not type inference);
+// see docs/decisions/0001-singular-embedded-messages-by-name.md.
 //
 // A singular embedded message field on an event is applied to the aggregate by
 // the generated On() via a plain by-NAME copy (aggregate.Foo = e.GetFoo()), the

--- a/cmd/protoc-gen-protosource/protosourceify.go
+++ b/cmd/protoc-gen-protosource/protosourceify.go
@@ -186,11 +186,18 @@ func (p *ProtosourceModule) aggregateHasField(eventField pgs.Field, aggregate pg
 }
 
 // commandEventArg returns the Go expression passed to an event builder method
-// for eventField when emitting events from command cmd. If cmd has a field of
-// the same name, it is forwarded (m.GetX()); otherwise the field's zero value is
-// passed. The zero-value path supports "clear" events that carry an embedded
-// field the command intentionally omits — e.g. ClearBilling (no billing field)
-// emitting BillingCleared{billing: nil}, which On() copies to nil the field.
+// for eventField when emitting events from command cmd.
+//
+// If cmd has a field of the same name, it is forwarded (m.GetX()). If it does
+// not, behavior depends on the event field's type:
+//   - Nilable types (embedded message, bytes, map, repeated) emit nil. This is
+//     the "clear" pattern: e.g. ClearBilling (no billing field) emits
+//     BillingCleared{billing: nil}, which On() copies to nil the field.
+//   - Scalar types (string/bool/numeric/enum) fall through to a command getter
+//     anyway, which does NOT exist — so codegen fails to compile. This preserves
+//     the invariant that an event's scalar payload fields must line up with the
+//     command's, catching an accidentally-dropped field at build time instead of
+//     silently emitting a zero value.
 func (p *ProtosourceModule) commandEventArg(eventField pgs.Field, cmd pgs.Message) string {
 	for _, f := range cmd.Fields() {
 		if f.Name() == eventField.Name() {
@@ -204,14 +211,9 @@ func (p *ProtosourceModule) commandEventArg(eventField pgs.Field, cmd pgs.Messag
 	if t.IsRepeated() || t.IsMap() || t.IsEmbed() || t.ProtoType() == pgs.BytesT {
 		return "nil"
 	}
-	switch t.ProtoType() {
-	case pgs.StringT:
-		return `""`
-	case pgs.BoolT:
-		return "false"
-	default:
-		return "0" // numeric and enum (untyped 0 converts to the named type)
-	}
+	// Scalar field with no matching command field: emit a getter that does not
+	// exist on the command so the generated code fails to compile (fail-fast).
+	return "m.Get" + p.ctx.Name(eventField).String() + "()"
 }
 
 func (p *ProtosourceModule) messageOptions(m pgs.Message) *optionsv1.MessageOptions {

--- a/cmd/protoc-gen-protosource/protosourceify.go
+++ b/cmd/protoc-gen-protosource/protosourceify.go
@@ -194,7 +194,10 @@ func (p *ProtosourceModule) aggregateHasField(eventField pgs.Field, aggregate pg
 func (p *ProtosourceModule) commandEventArg(eventField pgs.Field, cmd pgs.Message) string {
 	for _, f := range cmd.Fields() {
 		if f.Name() == eventField.Name() {
-			return "m.Get" + p.ctx.Name(eventField).String() + "()"
+			// Getter name is derived from the command's own field (m is the
+			// command); the event field's GoName can differ if either message
+			// triggers protoc-gen-go name disambiguation.
+			return "m.Get" + p.ctx.Name(f).String() + "()"
 		}
 	}
 	t := eventField.Type()

--- a/cmd/protoc-gen-protosource/protosourceify.go
+++ b/cmd/protoc-gen-protosource/protosourceify.go
@@ -491,11 +491,12 @@ func (p *ProtosourceModule) validateSingularEmbed(evt pgs.Message, agg pgs.Messa
 		return nil
 	}
 	aggNames := map[string]bool{}
-	aggByFQN := map[string]string{} // embed type FQN -> aggregate field name (for the hint)
+	aggByFQN := map[string][]string{} // embed type FQN -> aggregate field name(s) of that type
 	for _, f := range agg.Fields() {
 		aggNames[f.Name().String()] = true
 		if isSingularEmbedField(f) {
-			aggByFQN[f.Type().Embed().FullyQualifiedName()] = f.Name().String()
+			fqn := f.Type().Embed().FullyQualifiedName()
+			aggByFQN[fqn] = append(aggByFQN[fqn], f.Name().String())
 		}
 	}
 	for _, ef := range evt.Fields() {
@@ -505,13 +506,25 @@ func (p *ProtosourceModule) validateSingularEmbed(evt pgs.Message, agg pgs.Messa
 		if aggNames[ef.Name().String()] {
 			continue // name matches an aggregate field — On() applies it by name
 		}
-		// Name doesn't match. If the aggregate has a singular embed of the same
-		// type under a different name, this is almost certainly a misnamed field.
-		if target, ok := aggByFQN[ef.Type().Embed().FullyQualifiedName()]; ok {
+		// Name doesn't match. If the aggregate has one or more singular embeds of
+		// the same type under a different name, this is almost certainly a
+		// misnamed field. List every candidate so the hint is unambiguous even
+		// when the aggregate has multiple fields of that type.
+		if targets, ok := aggByFQN[ef.Type().Embed().FullyQualifiedName()]; ok {
+			var hint string
+			if len(targets) == 1 {
+				hint = fmt.Sprintf("%q", targets[0])
+			} else {
+				quoted := make([]string, len(targets))
+				for i, t := range targets {
+					quoted[i] = fmt.Sprintf("%q", t)
+				}
+				hint = "one of " + strings.Join(quoted, ", ")
+			}
 			return fmt.Errorf(
-				"event %s: embedded field %q (type %s) will not be applied to aggregate %s: singular embedded fields are matched by field name and no aggregate field is named %q; rename the event field to %q to populate %s.%s",
+				"event %s: embedded field %q (type %s) will not be applied to aggregate %s: singular embedded fields are matched by field name and no aggregate field is named %q; rename the event field to match %s",
 				evt.Name(), ef.Name(), ef.Type().Embed().Name(), agg.Name(),
-				ef.Name(), target, agg.Name(), target)
+				ef.Name(), hint)
 		}
 	}
 	return nil

--- a/cmd/protoc-gen-protosource/protosourceify.go
+++ b/cmd/protoc-gen-protosource/protosourceify.go
@@ -533,7 +533,7 @@ func (p *ProtosourceModule) validateSingularEmbed(evt pgs.Message, agg pgs.Messa
 			}
 			return fmt.Errorf(
 				"event %s: embedded field %q (type %s) will not be applied to aggregate %s: singular embedded fields are matched by field name and no aggregate field is named %q; rename the event field to match %s",
-				evt.Name(), ef.Name(), ef.Type().Embed().Name(), agg.Name(),
+				evt.Name(), ef.Name(), ef.Type().Embed().FullyQualifiedName(), agg.Name(),
 				ef.Name(), hint)
 		}
 	}

--- a/cmd/protoc-gen-protosource/protosourceify.go
+++ b/cmd/protoc-gen-protosource/protosourceify.go
@@ -495,11 +495,16 @@ func (p *ProtosourceModule) validateSingularEmbed(evt pgs.Message, agg pgs.Messa
 	if p.eventCollectionMapping(evt) != nil {
 		return nil
 	}
-	aggNames := map[string]bool{}
+	// Track only *singular embed* aggregate field names for the early-continue.
+	// A name match against a non-embed field (scalar/map/repeated) does not mean
+	// On() will apply the embed — the by-name copy would be a Go type mismatch.
+	// Narrowing to singular embeds lets us still surface the rename hint when the
+	// aggregate has a same-typed embed under a different name.
+	aggEmbedNames := map[string]bool{}
 	aggByFQN := map[string][]string{} // embed type FQN -> aggregate field name(s) of that type
 	for _, f := range agg.Fields() {
-		aggNames[f.Name().String()] = true
 		if isSingularEmbedField(f) {
+			aggEmbedNames[f.Name().String()] = true
 			fqn := f.Type().Embed().FullyQualifiedName()
 			aggByFQN[fqn] = append(aggByFQN[fqn], f.Name().String())
 		}
@@ -508,8 +513,8 @@ func (p *ProtosourceModule) validateSingularEmbed(evt pgs.Message, agg pgs.Messa
 		if !isSingularEmbedField(ef) {
 			continue
 		}
-		if aggNames[ef.Name().String()] {
-			continue // name matches an aggregate field — On() applies it by name
+		if aggEmbedNames[ef.Name().String()] {
+			continue // name matches a singular-embed aggregate field — On() applies it by name
 		}
 		// Name doesn't match. If the aggregate has one or more singular embeds of
 		// the same type under a different name, this is almost certainly a

--- a/cmd/protoc-gen-protosource/protosourceify.go
+++ b/cmd/protoc-gen-protosource/protosourceify.go
@@ -435,6 +435,58 @@ func (p *ProtosourceModule) eventCollectionKeyField(m pgs.Message) string {
 	return cm.GetKeyField()
 }
 
+// isSingularEmbedField reports whether f is a singular (non-collection) embedded
+// message field — an embed that is neither a map nor a repeated field.
+func isSingularEmbedField(f pgs.Field) bool {
+	t := f.Type()
+	return t.IsEmbed() && !t.IsMap() && !t.IsRepeated()
+}
+
+// validateSingularEmbed enforces the singular embedded-message convention.
+//
+// A singular embedded message field on an event is applied to the aggregate by
+// the generated On() via a plain by-NAME copy (aggregate.Foo = e.GetFoo()), the
+// same mechanism used for scalar fields. A "set" event carries the populated
+// message; a "clear" event carries the same-named field left empty (the
+// unconditional copy then nils the aggregate field). There is intentionally no
+// type-based inference.
+//
+// The failure mode this guards against: an event carries an embedded message of
+// the right type but under a different field name than the aggregate uses. The
+// by-name copy then silently does nothing, leaving the aggregate field zero
+// after Apply/Load (the original GH#96 symptom). Rather than fail at runtime, we
+// fail codegen with a rename hint. Collection events (map add/remove) are exempt.
+func (p *ProtosourceModule) validateSingularEmbed(evt pgs.Message, agg pgs.Message) error {
+	if p.eventCollectionMapping(evt) != nil {
+		return nil
+	}
+	aggNames := map[string]bool{}
+	aggByFQN := map[string]string{} // embed type FQN -> aggregate field name (for the hint)
+	for _, f := range agg.Fields() {
+		aggNames[f.Name().String()] = true
+		if isSingularEmbedField(f) {
+			aggByFQN[f.Type().Embed().FullyQualifiedName()] = f.Name().String()
+		}
+	}
+	for _, ef := range evt.Fields() {
+		if !isSingularEmbedField(ef) {
+			continue
+		}
+		if aggNames[ef.Name().String()] {
+			continue // name matches an aggregate field — On() applies it by name
+		}
+		// Name doesn't match. If the aggregate has a singular embed of the same
+		// type under a different name, this is almost certainly a misnamed field.
+		if target, ok := aggByFQN[ef.Type().Embed().FullyQualifiedName()]; ok {
+			return fmt.Errorf(
+				"event %s: embedded field %q (type %s) will not be applied to aggregate %s: singular embedded fields are matched by field name and no aggregate field is named %q; rename the event field to %q to populate %s.%s",
+				evt.Name(), ef.Name(), ef.Type().Embed().Name(), agg.Name(),
+				ef.Name(), target, agg.Name(), target)
+		}
+	}
+	return nil
+}
+
 // validateCollectionMapping validates the collection annotation on an event message.
 // Collections use map<string, Message> fields on the aggregate.
 func (p *ProtosourceModule) validateCollectionMapping(evt pgs.Message, agg pgs.Message, f pgs.File) error {
@@ -1100,6 +1152,10 @@ func (p *ProtosourceModule) generate(f pgs.File) {
 			}
 			if agg != nil {
 				if err := p.validateCollectionMapping(m, agg, f); err != nil {
+					p.Fail(err.Error())
+					return
+				}
+				if err := p.validateSingularEmbed(m, agg); err != nil {
 					p.Fail(err.Error())
 					return
 				}

--- a/cmd/protoc-gen-protosource/protosourceify_test.go
+++ b/cmd/protoc-gen-protosource/protosourceify_test.go
@@ -619,5 +619,24 @@ func TestValidateSingularEmbed_NameMismatch(t *testing.T) {
 	}
 }
 
+func TestValidateSingularEmbed_NameMismatch_MultipleCandidates(t *testing.T) {
+	f := loadTestProto(t, "singular_embed_dual.proto")
+	p := newModule()
+	agg := findMessage(f, "Account")
+	evt := findMessage(f, "ProfileSet")
+	if agg == nil || evt == nil {
+		t.Fatal("messages not found")
+	}
+	// The aggregate has two Profile fields (primary, backup); the rename hint
+	// must list both, not an arbitrary one.
+	err := p.validateSingularEmbed(evt, agg)
+	if err == nil {
+		t.Fatal("expected error for name mismatch, got nil")
+	}
+	if !strings.Contains(err.Error(), "primary") || !strings.Contains(err.Error(), "backup") {
+		t.Errorf("error should list both candidate fields 'primary' and 'backup', got: %v", err)
+	}
+}
+
 // Ensure the optionsv1 import is used (extensions must be registered).
 var _ = optionsv1.E_ProtosourceMessageType

--- a/cmd/protoc-gen-protosource/protosourceify_test.go
+++ b/cmd/protoc-gen-protosource/protosourceify_test.go
@@ -638,5 +638,40 @@ func TestValidateSingularEmbed_NameMismatch_MultipleCandidates(t *testing.T) {
 	}
 }
 
+func fieldByName(t *testing.T, m pgs.Message, name string) pgs.Field {
+	t.Helper()
+	for _, f := range m.Fields() {
+		if f.Name().String() == name {
+			return f
+		}
+	}
+	t.Fatalf("field %q not found on %s", name, m.Name())
+	return nil
+}
+
+func TestCommandEventArg(t *testing.T) {
+	f := loadTestProto(t, "command_event_arg.proto")
+	p := newModule()
+	cmd := findMessage(f, "DoThing")
+	evt := findMessage(f, "ThingDone")
+	if cmd == nil || evt == nil {
+		t.Fatal("messages not found")
+	}
+
+	// Field present on the command -> forwarded getter.
+	if got := p.commandEventArg(fieldByName(t, evt, "actor"), cmd); got != "m.GetActor()" {
+		t.Errorf("actor (present): got %q, want m.GetActor()", got)
+	}
+	// Embedded message absent on the command -> nil (the clear pattern).
+	if got := p.commandEventArg(fieldByName(t, evt, "profile"), cmd); got != "nil" {
+		t.Errorf("profile (absent embed): got %q, want nil", got)
+	}
+	// Scalar absent on the command -> a command getter that does not exist, so
+	// codegen fails to compile rather than silently emitting a zero value.
+	if got := p.commandEventArg(fieldByName(t, evt, "note"), cmd); got != "m.GetNote()" {
+		t.Errorf("note (absent scalar): got %q, want m.GetNote() (fail-fast)", got)
+	}
+}
+
 // Ensure the optionsv1 import is used (extensions must be registered).
 var _ = optionsv1.E_ProtosourceMessageType

--- a/cmd/protoc-gen-protosource/protosourceify_test.go
+++ b/cmd/protoc-gen-protosource/protosourceify_test.go
@@ -577,5 +577,47 @@ func TestValidateProjectionFields_MapValueMessageMismatch(t *testing.T) {
 	}
 }
 
+// --- Singular embedded message convention (by-name) ---
+
+func TestValidateSingularEmbed_NameMatch(t *testing.T) {
+	f := loadTestProto(t, "singular_embed_valid.proto")
+	p := newModule()
+	agg := findMessage(f, "Account")
+	if agg == nil {
+		t.Fatal("aggregate Account not found")
+	}
+	// Both set and clear events name their embed field to match the aggregate
+	// field (profile), so On()'s by-name copy applies them — no error.
+	for _, name := range []string{"ProfileSet", "ProfileCleared"} {
+		evt := findMessage(f, name)
+		if evt == nil {
+			t.Fatalf("event %s not found", name)
+		}
+		if err := p.validateSingularEmbed(evt, agg); err != nil {
+			t.Errorf("validateSingularEmbed(%s) unexpected error: %v", name, err)
+		}
+	}
+}
+
+func TestValidateSingularEmbed_NameMismatch(t *testing.T) {
+	f := loadTestProto(t, "singular_embed_mismatch.proto")
+	p := newModule()
+	agg := findMessage(f, "Account")
+	evt := findMessage(f, "ProfileSet")
+	if agg == nil || evt == nil {
+		t.Fatal("messages not found")
+	}
+	// Event carries a Profile under the wrong name ("config"); the aggregate
+	// field is "profile". The by-name copy would silently skip it, so codegen
+	// must fail with a rename hint.
+	err := p.validateSingularEmbed(evt, agg)
+	if err == nil {
+		t.Fatal("expected error for name mismatch, got nil")
+	}
+	if !strings.Contains(err.Error(), "config") || !strings.Contains(err.Error(), "profile") {
+		t.Errorf("error should name the offending field 'config' and the target 'profile', got: %v", err)
+	}
+}
+
 // Ensure the optionsv1 import is used (extensions must be registered).
 var _ = optionsv1.E_ProtosourceMessageType

--- a/cmd/protoc-gen-protosource/testdata/command_event_arg.proto
+++ b/cmd/protoc-gen-protosource/testdata/command_event_arg.proto
@@ -1,0 +1,48 @@
+syntax = "proto3";
+
+package test.command_event_arg;
+
+option go_package = "github.com/funinthecloud/protosource/test/command_event_arg;ceapb";
+
+import "funinthecloud/protosource/options/v1/options_v1.proto";
+
+option (funinthecloud.protosource.options.v1.protosource_file).enabled = true;
+
+message Thing {
+  option (funinthecloud.protosource.options.v1.protosource_message_type).aggregate = {
+  };
+  string  id        = 1;
+  int64   version   = 2;
+  int64   create_at = 3;
+  string  create_by = 4;
+  int64   modify_at = 5;
+  string  modify_by = 6;
+  string  note      = 7;
+  Profile profile   = 8;
+}
+
+message Profile {
+  string display_name = 1;
+}
+
+// Command with no domain fields (only the id/actor contract fields).
+message DoThing {
+  option (funinthecloud.protosource.options.v1.protosource_message_type).command = {
+    produces_events: [ "ThingDone" ]
+    lifecycle: COMMAND_LIFECYCLE_MUTATION
+  };
+  string id    = 1;
+  string actor = 2;
+}
+
+// Event carrying a scalar (note) and an embed (profile) absent on DoThing.
+message ThingDone {
+  option (funinthecloud.protosource.options.v1.protosource_message_type).event = {
+  };
+  string  id      = 1;
+  int64   version = 2;
+  int64   at      = 3;
+  string  actor   = 4;
+  string  note    = 5;
+  Profile profile = 6;
+}

--- a/cmd/protoc-gen-protosource/testdata/singular_embed_dual.proto
+++ b/cmd/protoc-gen-protosource/testdata/singular_embed_dual.proto
@@ -1,0 +1,45 @@
+syntax = "proto3";
+
+package test.singular_embed_dual;
+
+option go_package = "github.com/funinthecloud/protosource/test/singular_embed_dual;sedpb";
+
+import "funinthecloud/protosource/options/v1/options_v1.proto";
+
+option (funinthecloud.protosource.options.v1.protosource_file).enabled = true;
+
+enum State {
+  STATE_UNSPECIFIED = 0;
+  STATE_ACTIVE      = 1;
+}
+
+// Aggregate with TWO singular embeds of the SAME type (Profile).
+message Account {
+  option (funinthecloud.protosource.options.v1.protosource_message_type).aggregate = {
+  };
+  string  id        = 1;
+  int64   version   = 2;
+  int64   create_at = 3;
+  string  create_by = 4;
+  int64   modify_at = 5;
+  string  modify_by = 6;
+  State   state     = 7;
+  Profile primary   = 8;
+  Profile backup    = 9;
+}
+
+message Profile {
+  string display_name = 1;
+}
+
+// Carries a Profile under a name matching NEITHER aggregate field -> the rename
+// hint must list both candidates (primary, backup).
+message ProfileSet {
+  option (funinthecloud.protosource.options.v1.protosource_message_type).event = {
+  };
+  string  id      = 1;
+  int64   version = 2;
+  int64   at      = 3;
+  string  actor   = 4;
+  Profile config  = 5;
+}

--- a/cmd/protoc-gen-protosource/testdata/singular_embed_mismatch.proto
+++ b/cmd/protoc-gen-protosource/testdata/singular_embed_mismatch.proto
@@ -1,0 +1,54 @@
+syntax = "proto3";
+
+package test.singular_embed_mismatch;
+
+option go_package = "github.com/funinthecloud/protosource/test/singular_embed_mismatch;sevmpb";
+
+import "funinthecloud/protosource/options/v1/options_v1.proto";
+
+option (funinthecloud.protosource.options.v1.protosource_file).enabled = true;
+
+enum State {
+  STATE_UNSPECIFIED = 0;
+  STATE_ACTIVE      = 1;
+}
+
+message Account {
+  option (funinthecloud.protosource.options.v1.protosource_message_type).aggregate = {
+  };
+  string  id        = 1;
+  int64   version   = 2;
+  int64   create_at = 3;
+  string  create_by = 4;
+  int64   modify_at = 5;
+  string  modify_by = 6;
+  State   state     = 7;
+  Profile profile   = 8;  // singular embedded message
+}
+
+message Profile {
+  string display_name = 1;
+  string locale       = 2;
+}
+
+// Set event: carries a populated, same-named embed -> On() copies it in.
+message ProfileSet {
+  option (funinthecloud.protosource.options.v1.protosource_message_type).event = {
+  };
+  string  id      = 1;
+  int64   version = 2;
+  int64   at      = 3;
+  string  actor   = 4;
+  Profile config  = 5;
+}
+
+// Clear event: carries the same-named embed left empty -> On() nils the field.
+message ProfileCleared {
+  option (funinthecloud.protosource.options.v1.protosource_message_type).event = {
+  };
+  string  id      = 1;
+  int64   version = 2;
+  int64   at      = 3;
+  string  actor   = 4;
+  Profile config  = 5;
+}

--- a/cmd/protoc-gen-protosource/testdata/singular_embed_mismatch.proto
+++ b/cmd/protoc-gen-protosource/testdata/singular_embed_mismatch.proto
@@ -31,7 +31,8 @@ message Profile {
   string locale       = 2;
 }
 
-// Set event: carries a populated, same-named embed -> On() copies it in.
+// Set event: the embed is DELIBERATELY misnamed "config" (the aggregate field
+// is "profile") to exercise validateSingularEmbed's failure path.
 message ProfileSet {
   option (funinthecloud.protosource.options.v1.protosource_message_type).event = {
   };
@@ -42,7 +43,8 @@ message ProfileSet {
   Profile config  = 5;
 }
 
-// Clear event: carries the same-named embed left empty -> On() nils the field.
+// Clear event: also deliberately misnamed "config" (not "profile") — same
+// failure path as the set event above.
 message ProfileCleared {
   option (funinthecloud.protosource.options.v1.protosource_message_type).event = {
   };

--- a/cmd/protoc-gen-protosource/testdata/singular_embed_valid.proto
+++ b/cmd/protoc-gen-protosource/testdata/singular_embed_valid.proto
@@ -42,7 +42,8 @@ message ProfileSet {
   Profile profile = 5;
 }
 
-// Clear event: carries the same-named embed left empty -> On() nils the field.
+// Clear event: declares the same-named embed; emitted unset (nil), On() nils the
+// field. (A present-but-empty Profile{} is non-nil and would not clear.)
 message ProfileCleared {
   option (funinthecloud.protosource.options.v1.protosource_message_type).event = {
   };

--- a/cmd/protoc-gen-protosource/testdata/singular_embed_valid.proto
+++ b/cmd/protoc-gen-protosource/testdata/singular_embed_valid.proto
@@ -1,0 +1,54 @@
+syntax = "proto3";
+
+package test.singular_embed_valid;
+
+option go_package = "github.com/funinthecloud/protosource/test/singular_embed_valid;sevpb";
+
+import "funinthecloud/protosource/options/v1/options_v1.proto";
+
+option (funinthecloud.protosource.options.v1.protosource_file).enabled = true;
+
+enum State {
+  STATE_UNSPECIFIED = 0;
+  STATE_ACTIVE      = 1;
+}
+
+message Account {
+  option (funinthecloud.protosource.options.v1.protosource_message_type).aggregate = {
+  };
+  string  id        = 1;
+  int64   version   = 2;
+  int64   create_at = 3;
+  string  create_by = 4;
+  int64   modify_at = 5;
+  string  modify_by = 6;
+  State   state     = 7;
+  Profile profile   = 8;  // singular embedded message
+}
+
+message Profile {
+  string display_name = 1;
+  string locale       = 2;
+}
+
+// Set event: carries a populated, same-named embed -> On() copies it in.
+message ProfileSet {
+  option (funinthecloud.protosource.options.v1.protosource_message_type).event = {
+  };
+  string  id      = 1;
+  int64   version = 2;
+  int64   at      = 3;
+  string  actor   = 4;
+  Profile profile = 5;
+}
+
+// Clear event: carries the same-named embed left empty -> On() nils the field.
+message ProfileCleared {
+  option (funinthecloud.protosource.options.v1.protosource_message_type).event = {
+  };
+  string  id      = 1;
+  int64   version = 2;
+  int64   at      = 3;
+  string  actor   = 4;
+  Profile profile = 5;
+}

--- a/docs/decisions/0001-singular-embedded-messages-by-name.md
+++ b/docs/decisions/0001-singular-embedded-messages-by-name.md
@@ -26,16 +26,18 @@ field name matches the aggregate field — and that the inference was redundant.
 
 Apply singular embedded message fields by the **same by-name mechanism used for
 scalars**. The convention: name the event's embedded field to match the aggregate
-field. A "set" event carries the populated message; a "clear" event carries the
-same-named field left empty, and `On()`'s unconditional copy nils it. No new
-annotation, no type inference, no template branch for the set/clear itself.
+field. A "set" event carries the populated message; a "clear" event leaves the
+same-named field **unset (nil)**, and `On()`'s unconditional copy assigns that
+nil. (A present-but-empty `&Msg{}` is non-nil and would not clear — clearing
+depends on the field being unset.) No new annotation, no type inference, no
+template branch for the set/clear itself.
 
 Two supporting pieces were added:
 - `validateSingularEmbed` fails codegen when an event carries an embedded message
   of a type present on the aggregate but under a **different** field name (the
   silent no-op that was the original GH#96 symptom), with a rename hint.
 - `commandEventArg` lets `EmitEvents` pass a zero value when a command lacks an
-  event field, so a clear command (no embed) can emit a clear event (empty embed).
+  event field, so a clear command (no embed) emits the event field unset (nil).
 
 ## Rejected alternatives
 
@@ -59,13 +61,14 @@ Two supporting pieces were added:
 - Easier: singular embeds need zero framework code on the `On()` side; the
   ambiguity class disappears (field names are unique by construction); two
   same-typed fields are trivially distinguished by name.
-- Harder / risk: "clear" is opt-in by convention — an event must carry an empty
-  same-named field, and `validateSingularEmbed` *cannot* enforce that a clear
-  event was written (an event that omits the field is indistinguishable from one
-  that intentionally doesn't touch it). This is documented, not validated.
+- Harder / risk: "clear" is opt-in by convention — a clear event declares the
+  same-named field and emits it **unset (nil)** (a present-but-empty message does
+  not clear), and `validateSingularEmbed` *cannot* enforce that a clear event was
+  written (an event that omits the field is indistinguishable from one that
+  intentionally doesn't touch it). This is documented, not validated.
 - Load-bearing: the set/clear behavior depends on the generated copy being
   **unconditional**. `TestBilling_SetThenClear` (order example) guards it through
   Apply→Load so a future nil-guard "optimization" can't silently break clears.
 - Cross-repo: protosource-auth must rename `OIDCConfigSet.config` → `oidc` and add
-  an empty `OIDCConfig oidc` to `OIDCConfigCleared`; the validator turns the first
-  into a build failure (good), but not the second.
+  an `OIDCConfig oidc` field to `OIDCConfigCleared` that is emitted unset (nil);
+  the validator turns the first into a build failure (good), but not the second.

--- a/docs/decisions/0001-singular-embedded-messages-by-name.md
+++ b/docs/decisions/0001-singular-embedded-messages-by-name.md
@@ -1,0 +1,71 @@
+# 0001. Singular embedded message fields applied by name, not by inference
+
+- Status: Accepted
+- Date: 2026-06-25
+
+## Context
+
+Aggregates already support two ways of populating fields in the generated
+`On(event)` method: scalar fields are copied by matching field **name**
+(`aggregate.Foo = e.GetFoo()`), and collection (`map<string, Message>`) fields
+use an explicit `collection:` annotation (ADD/REMOVE, target, key_field).
+
+There was no story for a **singular** (non-collection) embedded message field on
+an aggregate — e.g. `OidcConfig oidc = 13` on an `Issuer`. When an event carried
+such a sub-message, `On()` emitted only `setModified(e)` and never assigned the
+field, forcing consumers (protosource-auth's OIDC federation, GH#96) to hand-edit
+generated files — a patch `buf generate` clobbers in CI.
+
+A first implementation (PR #97, later reverted) matched the event's embed to the
+aggregate field by message **type** and inferred the assignment, plus a
+name-suffix heuristic for "clear" events. Review and a generation experiment then
+showed the existing scalar path already handles a singular embed when the event
+field name matches the aggregate field — and that the inference was redundant.
+
+## Decision
+
+Apply singular embedded message fields by the **same by-name mechanism used for
+scalars**. The convention: name the event's embedded field to match the aggregate
+field. A "set" event carries the populated message; a "clear" event carries the
+same-named field left empty, and `On()`'s unconditional copy nils it. No new
+annotation, no type inference, no template branch for the set/clear itself.
+
+Two supporting pieces were added:
+- `validateSingularEmbed` fails codegen when an event carries an embedded message
+  of a type present on the aggregate but under a **different** field name (the
+  silent no-op that was the original GH#96 symptom), with a rename hint.
+- `commandEventArg` lets `EmitEvents` pass a zero value when a command lacks an
+  event field, so a clear command (no embed) can emit a clear event (empty embed).
+
+## Rejected alternatives
+
+- **Type-based inference (the original PR #97 approach)** — rejected because
+  matching by message type is a non-unique key: an aggregate with two fields of
+  the same message type cannot be disambiguated, so the generator had to *refuse*
+  those cases, and it emitted a duplicate assignment alongside the scalar copy. It
+  existed only to tolerate divergent field names (`config` vs `oidc`), which is
+  not a requirement — names can simply be made to match.
+- **Explicit `SingularMessageMapping`/`target:` annotation (parallel to
+  `collection:`)** — rejected because it adds annotation surface and per-event
+  ceremony to express something the by-name scalar copy already does for free.
+  Reconsider only if a real need arises to route an embed to a differently-named
+  aggregate field (e.g. a single event setting one of two same-typed fields).
+- **Keep inference but fix its warts** — rejected because it preserves the
+  unprincipled middle: still type-keyed, still ambiguous, still needs a clear
+  heuristic, for no benefit over by-name.
+
+## Consequences
+
+- Easier: singular embeds need zero framework code on the `On()` side; the
+  ambiguity class disappears (field names are unique by construction); two
+  same-typed fields are trivially distinguished by name.
+- Harder / risk: "clear" is opt-in by convention — an event must carry an empty
+  same-named field, and `validateSingularEmbed` *cannot* enforce that a clear
+  event was written (an event that omits the field is indistinguishable from one
+  that intentionally doesn't touch it). This is documented, not validated.
+- Load-bearing: the set/clear behavior depends on the generated copy being
+  **unconditional**. `TestBilling_SetThenClear` (order example) guards it through
+  Apply→Load so a future nil-guard "optimization" can't silently break clears.
+- Cross-repo: protosource-auth must rename `OIDCConfigSet.config` → `oidc` and add
+  an empty `OIDCConfig oidc` to `OIDCConfigCleared`; the validator turns the first
+  into a build failure (good), but not the second.

--- a/gen/example/app/order/v1/order_billing_test.go
+++ b/gen/example/app/order/v1/order_billing_test.go
@@ -67,3 +67,30 @@ func TestBilling_SetThenClear(t *testing.T) {
 		t.Errorf("after ClearBilling, billing = %+v, want nil", b)
 	}
 }
+
+// TestSetBilling_RequiresBilling guards the protovalidate (required) constraint
+// on SetBilling.billing. A "set" command with no embed would otherwise emit
+// BillingSet{billing=nil}, which On() copies — silently clearing Order.billing
+// under a set event. ProtoValidate must reject it so clearing stays the explicit
+// ClearBilling command's job.
+func TestSetBilling_RequiresBilling(t *testing.T) {
+	repo := newOrderRepo(t)
+	ctx := context.Background()
+
+	if _, err := repo.Apply(ctx, &orderv1.Create{
+		Id:           "order-bv",
+		Actor:        "alice",
+		CustomerId:   "cust-1",
+		CustomerName: "Alice",
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// SetBilling with billing unset must fail validation, not silently clear.
+	if _, err := repo.Apply(ctx, &orderv1.SetBilling{
+		Id:    "order-bv",
+		Actor: "alice",
+	}); err == nil {
+		t.Fatal("SetBilling with nil billing: got nil error, want validation failure")
+	}
+}

--- a/gen/example/app/order/v1/order_billing_test.go
+++ b/gen/example/app/order/v1/order_billing_test.go
@@ -1,0 +1,69 @@
+package orderv1_test
+
+import (
+	"context"
+	"testing"
+
+	orderv1 "github.com/funinthecloud/protosource/gen/example/app/order/v1"
+)
+
+// TestBilling_SetThenClear exercises the singular embedded-message convention
+// end to end through Apply -> Load.
+//
+// It guards the load-bearing semantic the whole convention rests on: On()
+// applies a singular embed by NAME via an *unconditional* copy
+// (aggregate.Billing = e.GetBilling()). A populated same-named embed therefore
+// sets the field, and a clear command — which carries no embed, so the emitted
+// event's billing field is nil — clears it. If the generated copy ever became
+// nil-guarded, the clear would silently stop working and this test would fail.
+func TestBilling_SetThenClear(t *testing.T) {
+	repo := newOrderRepo(t)
+	ctx := context.Background()
+
+	if _, err := repo.Apply(ctx, &orderv1.Create{
+		Id:           "order-b",
+		Actor:        "alice",
+		CustomerId:   "cust-1",
+		CustomerName: "Alice",
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Set: the command carries a populated, same-named embed.
+	if _, err := repo.Apply(ctx, &orderv1.SetBilling{
+		Id:      "order-b",
+		Actor:   "alice",
+		Billing: &orderv1.Billing{Method: "card", Reference: "ref-123"},
+	}); err != nil {
+		t.Fatalf("SetBilling: %v", err)
+	}
+
+	got, err := repo.Load(ctx, "order-b")
+	if err != nil {
+		t.Fatalf("Load after set: %v", err)
+	}
+	billing := got.(*orderv1.Order).GetBilling()
+	if billing == nil {
+		t.Fatal("after SetBilling, billing is nil; want populated")
+	}
+	if billing.GetMethod() != "card" || billing.GetReference() != "ref-123" {
+		t.Errorf("billing = %+v, want method=card reference=ref-123", billing)
+	}
+
+	// Clear: the command carries no embed, so the event's billing field is empty
+	// and the unconditional copy nils the aggregate field.
+	if _, err := repo.Apply(ctx, &orderv1.ClearBilling{
+		Id:    "order-b",
+		Actor: "alice",
+	}); err != nil {
+		t.Fatalf("ClearBilling: %v", err)
+	}
+
+	got, err = repo.Load(ctx, "order-b")
+	if err != nil {
+		t.Fatalf("Load after clear: %v", err)
+	}
+	if b := got.(*orderv1.Order).GetBilling(); b != nil {
+		t.Errorf("after ClearBilling, billing = %+v, want nil", b)
+	}
+}

--- a/gen/example/app/order/v1/order_v1.pb.go
+++ b/gen/example/app/order/v1/order_v1.pb.go
@@ -416,7 +416,8 @@ func (x *Tag) GetValue() string {
 // Billing is a singular embedded value object on the Order. It is set and
 // cleared by the by-name convention (no annotation): the BillingSet/
 // BillingCleared events carry a field literally named "billing", which On()
-// copies into Order.billing — populated to set, empty to clear.
+// copies into Order.billing — populated to set, unset (nil) to clear. Note a
+// present-but-empty &Billing{} is non-nil and would NOT clear.
 type Billing struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Method        string                 `protobuf:"bytes,1,opt,name=method,proto3" json:"method,omitempty"`       // e.g. "card", "invoice"
@@ -1611,8 +1612,10 @@ func (x *BillingSet) GetBilling() *Billing {
 	return nil
 }
 
-// BillingCleared carries an empty same-named "billing" embed; the unconditional
-// by-name copy in On() resolves it to nil, clearing Order.billing.
+// BillingCleared declares a same-named "billing" embed but emits it unset (the
+// ClearBilling command carries no billing, so EmitEvents passes nil). On()'s
+// unconditional by-name copy then assigns nil, clearing Order.billing. The field
+// must be unset (nil) to clear — a present-but-empty &Billing{} would not.
 type BillingCleared struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`

--- a/gen/example/app/order/v1/order_v1.pb.go
+++ b/gen/example/app/order/v1/order_v1.pb.go
@@ -7,6 +7,7 @@
 package orderv1
 
 import (
+	_ "buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go/buf/validate"
 	_ "github.com/funinthecloud/protosource/gen/options/v1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -839,10 +840,15 @@ func (x *SetShipping) GetShippingAddress() string {
 }
 
 type SetBilling struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
-	Actor         string                 `protobuf:"bytes,2,opt,name=actor,proto3" json:"actor,omitempty"`
-	Billing       *Billing               `protobuf:"bytes,3,opt,name=billing,proto3" json:"billing,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Id    string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Actor string                 `protobuf:"bytes,2,opt,name=actor,proto3" json:"actor,omitempty"`
+	// required: SetBilling must carry a populated embed. Without this, a
+	// SetBilling with billing unset would pass ProtoValidate and emit
+	// BillingSet{billing=nil}, which On() copies — silently clearing
+	// Order.billing under a "set" event. Clearing is the explicit ClearBilling
+	// command's job. See docs/decisions/0001-singular-embedded-messages-by-name.md.
+	Billing       *Billing `protobuf:"bytes,3,opt,name=billing,proto3" json:"billing,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2028,7 +2034,7 @@ var File_example_app_order_v1_order_v1_proto protoreflect.FileDescriptor
 
 const file_example_app_order_v1_order_v1_proto_rawDesc = "" +
 	"\n" +
-	"#example/app/order/v1/order_v1.proto\x12\x14example.app.order.v1\x1a5funinthecloud/protosource/options/v1/options_v1.proto\"\xa1\x06\n" +
+	"#example/app/order/v1/order_v1.proto\x12\x14example.app.order.v1\x1a\x1bbuf/validate/validate.proto\x1a5funinthecloud/protosource/options/v1/options_v1.proto\"\xa1\x06\n" +
 	"\x05Order\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x18\n" +
 	"\aversion\x18\x02 \x01(\x03R\aversion\x121\n" +
@@ -2112,12 +2118,12 @@ const file_example_app_order_v1_order_v1_proto_rawDesc = "" +
 	"\x05actor\x18\x02 \x01(\tR\x05actor\x12)\n" +
 	"\x10shipping_address\x18\x03 \x01(\tR\x0fshippingAddress:!\x8aQ\x1e\n" +
 	"\x1c\n" +
-	"\vShippingSet\x10\x02\x1a\vSTATE_DRAFT\"\x80\x01\n" +
+	"\vShippingSet\x10\x02\x1a\vSTATE_DRAFT\"\x88\x01\n" +
 	"\n" +
 	"SetBilling\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x14\n" +
-	"\x05actor\x18\x02 \x01(\tR\x05actor\x127\n" +
-	"\abilling\x18\x03 \x01(\v2\x1d.example.app.order.v1.BillingR\abilling:\x13\x8aQ\x10\n" +
+	"\x05actor\x18\x02 \x01(\tR\x05actor\x12?\n" +
+	"\abilling\x18\x03 \x01(\v2\x1d.example.app.order.v1.BillingB\x06\xbaH\x03\xc8\x01\x01R\abilling:\x13\x8aQ\x10\n" +
 	"\x0e\n" +
 	"\n" +
 	"BillingSet\x10\x02\"M\n" +

--- a/gen/example/app/order/v1/order_v1.pb.go
+++ b/gen/example/app/order/v1/order_v1.pb.go
@@ -100,6 +100,7 @@ type Order struct {
 	PlacedAt        int64                  `protobuf:"varint,13,opt,name=placed_at,json=placedAt,proto3" json:"placed_at,omitempty"`
 	Items           map[string]*LineItem   `protobuf:"bytes,14,rep,name=items,proto3" json:"items,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	Tags            map[string]*Tag        `protobuf:"bytes,15,rep,name=tags,proto3" json:"tags,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Billing         *Billing               `protobuf:"bytes,16,opt,name=billing,proto3" json:"billing,omitempty"`
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
@@ -235,6 +236,13 @@ func (x *Order) GetItems() map[string]*LineItem {
 func (x *Order) GetTags() map[string]*Tag {
 	if x != nil {
 		return x.Tags
+	}
+	return nil
+}
+
+func (x *Order) GetBilling() *Billing {
+	if x != nil {
+		return x.Billing
 	}
 	return nil
 }
@@ -405,6 +413,62 @@ func (x *Tag) GetValue() string {
 	return ""
 }
 
+// Billing is a singular embedded value object on the Order. It is set and
+// cleared by the by-name convention (no annotation): the BillingSet/
+// BillingCleared events carry a field literally named "billing", which On()
+// copies into Order.billing — populated to set, empty to clear.
+type Billing struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Method        string                 `protobuf:"bytes,1,opt,name=method,proto3" json:"method,omitempty"`       // e.g. "card", "invoice"
+	Reference     string                 `protobuf:"bytes,2,opt,name=reference,proto3" json:"reference,omitempty"` // opaque payment reference
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Billing) Reset() {
+	*x = Billing{}
+	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Billing) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Billing) ProtoMessage() {}
+
+func (x *Billing) ProtoReflect() protoreflect.Message {
+	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Billing.ProtoReflect.Descriptor instead.
+func (*Billing) Descriptor() ([]byte, []int) {
+	return file_example_app_order_v1_order_v1_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *Billing) GetMethod() string {
+	if x != nil {
+		return x.Method
+	}
+	return ""
+}
+
+func (x *Billing) GetReference() string {
+	if x != nil {
+		return x.Reference
+	}
+	return ""
+}
+
 type Create struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
@@ -417,7 +481,7 @@ type Create struct {
 
 func (x *Create) Reset() {
 	*x = Create{}
-	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[4]
+	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -429,7 +493,7 @@ func (x *Create) String() string {
 func (*Create) ProtoMessage() {}
 
 func (x *Create) ProtoReflect() protoreflect.Message {
-	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[4]
+	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -442,7 +506,7 @@ func (x *Create) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Create.ProtoReflect.Descriptor instead.
 func (*Create) Descriptor() ([]byte, []int) {
-	return file_example_app_order_v1_order_v1_proto_rawDescGZIP(), []int{4}
+	return file_example_app_order_v1_order_v1_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *Create) GetId() string {
@@ -484,7 +548,7 @@ type AddItem struct {
 
 func (x *AddItem) Reset() {
 	*x = AddItem{}
-	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[5]
+	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -496,7 +560,7 @@ func (x *AddItem) String() string {
 func (*AddItem) ProtoMessage() {}
 
 func (x *AddItem) ProtoReflect() protoreflect.Message {
-	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[5]
+	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -509,7 +573,7 @@ func (x *AddItem) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddItem.ProtoReflect.Descriptor instead.
 func (*AddItem) Descriptor() ([]byte, []int) {
-	return file_example_app_order_v1_order_v1_proto_rawDescGZIP(), []int{5}
+	return file_example_app_order_v1_order_v1_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *AddItem) GetId() string {
@@ -544,7 +608,7 @@ type RemoveItem struct {
 
 func (x *RemoveItem) Reset() {
 	*x = RemoveItem{}
-	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[6]
+	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -556,7 +620,7 @@ func (x *RemoveItem) String() string {
 func (*RemoveItem) ProtoMessage() {}
 
 func (x *RemoveItem) ProtoReflect() protoreflect.Message {
-	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[6]
+	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -569,7 +633,7 @@ func (x *RemoveItem) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveItem.ProtoReflect.Descriptor instead.
 func (*RemoveItem) Descriptor() ([]byte, []int) {
-	return file_example_app_order_v1_order_v1_proto_rawDescGZIP(), []int{6}
+	return file_example_app_order_v1_order_v1_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *RemoveItem) GetId() string {
@@ -604,7 +668,7 @@ type AddTag struct {
 
 func (x *AddTag) Reset() {
 	*x = AddTag{}
-	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[7]
+	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -616,7 +680,7 @@ func (x *AddTag) String() string {
 func (*AddTag) ProtoMessage() {}
 
 func (x *AddTag) ProtoReflect() protoreflect.Message {
-	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[7]
+	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -629,7 +693,7 @@ func (x *AddTag) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddTag.ProtoReflect.Descriptor instead.
 func (*AddTag) Descriptor() ([]byte, []int) {
-	return file_example_app_order_v1_order_v1_proto_rawDescGZIP(), []int{7}
+	return file_example_app_order_v1_order_v1_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *AddTag) GetId() string {
@@ -664,7 +728,7 @@ type RemoveTag struct {
 
 func (x *RemoveTag) Reset() {
 	*x = RemoveTag{}
-	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[8]
+	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -676,7 +740,7 @@ func (x *RemoveTag) String() string {
 func (*RemoveTag) ProtoMessage() {}
 
 func (x *RemoveTag) ProtoReflect() protoreflect.Message {
-	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[8]
+	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -689,7 +753,7 @@ func (x *RemoveTag) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveTag.ProtoReflect.Descriptor instead.
 func (*RemoveTag) Descriptor() ([]byte, []int) {
-	return file_example_app_order_v1_order_v1_proto_rawDescGZIP(), []int{8}
+	return file_example_app_order_v1_order_v1_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *RemoveTag) GetId() string {
@@ -724,7 +788,7 @@ type SetShipping struct {
 
 func (x *SetShipping) Reset() {
 	*x = SetShipping{}
-	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[9]
+	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -736,7 +800,7 @@ func (x *SetShipping) String() string {
 func (*SetShipping) ProtoMessage() {}
 
 func (x *SetShipping) ProtoReflect() protoreflect.Message {
-	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[9]
+	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -749,7 +813,7 @@ func (x *SetShipping) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetShipping.ProtoReflect.Descriptor instead.
 func (*SetShipping) Descriptor() ([]byte, []int) {
-	return file_example_app_order_v1_order_v1_proto_rawDescGZIP(), []int{9}
+	return file_example_app_order_v1_order_v1_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *SetShipping) GetId() string {
@@ -773,6 +837,118 @@ func (x *SetShipping) GetShippingAddress() string {
 	return ""
 }
 
+type SetBilling struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Actor         string                 `protobuf:"bytes,2,opt,name=actor,proto3" json:"actor,omitempty"`
+	Billing       *Billing               `protobuf:"bytes,3,opt,name=billing,proto3" json:"billing,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SetBilling) Reset() {
+	*x = SetBilling{}
+	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SetBilling) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SetBilling) ProtoMessage() {}
+
+func (x *SetBilling) ProtoReflect() protoreflect.Message {
+	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SetBilling.ProtoReflect.Descriptor instead.
+func (*SetBilling) Descriptor() ([]byte, []int) {
+	return file_example_app_order_v1_order_v1_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *SetBilling) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *SetBilling) GetActor() string {
+	if x != nil {
+		return x.Actor
+	}
+	return ""
+}
+
+func (x *SetBilling) GetBilling() *Billing {
+	if x != nil {
+		return x.Billing
+	}
+	return nil
+}
+
+type ClearBilling struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Actor         string                 `protobuf:"bytes,2,opt,name=actor,proto3" json:"actor,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ClearBilling) Reset() {
+	*x = ClearBilling{}
+	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ClearBilling) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ClearBilling) ProtoMessage() {}
+
+func (x *ClearBilling) ProtoReflect() protoreflect.Message {
+	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ClearBilling.ProtoReflect.Descriptor instead.
+func (*ClearBilling) Descriptor() ([]byte, []int) {
+	return file_example_app_order_v1_order_v1_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *ClearBilling) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *ClearBilling) GetActor() string {
+	if x != nil {
+		return x.Actor
+	}
+	return ""
+}
+
 type Place struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
@@ -784,7 +960,7 @@ type Place struct {
 
 func (x *Place) Reset() {
 	*x = Place{}
-	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[10]
+	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -796,7 +972,7 @@ func (x *Place) String() string {
 func (*Place) ProtoMessage() {}
 
 func (x *Place) ProtoReflect() protoreflect.Message {
-	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[10]
+	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -809,7 +985,7 @@ func (x *Place) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Place.ProtoReflect.Descriptor instead.
 func (*Place) Descriptor() ([]byte, []int) {
-	return file_example_app_order_v1_order_v1_proto_rawDescGZIP(), []int{10}
+	return file_example_app_order_v1_order_v1_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *Place) GetId() string {
@@ -844,7 +1020,7 @@ type Cancel struct {
 
 func (x *Cancel) Reset() {
 	*x = Cancel{}
-	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[11]
+	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -856,7 +1032,7 @@ func (x *Cancel) String() string {
 func (*Cancel) ProtoMessage() {}
 
 func (x *Cancel) ProtoReflect() protoreflect.Message {
-	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[11]
+	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -869,7 +1045,7 @@ func (x *Cancel) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Cancel.ProtoReflect.Descriptor instead.
 func (*Cancel) Descriptor() ([]byte, []int) {
-	return file_example_app_order_v1_order_v1_proto_rawDescGZIP(), []int{11}
+	return file_example_app_order_v1_order_v1_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *Cancel) GetId() string {
@@ -907,7 +1083,7 @@ type Created struct {
 
 func (x *Created) Reset() {
 	*x = Created{}
-	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[12]
+	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -919,7 +1095,7 @@ func (x *Created) String() string {
 func (*Created) ProtoMessage() {}
 
 func (x *Created) ProtoReflect() protoreflect.Message {
-	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[12]
+	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -932,7 +1108,7 @@ func (x *Created) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Created.ProtoReflect.Descriptor instead.
 func (*Created) Descriptor() ([]byte, []int) {
-	return file_example_app_order_v1_order_v1_proto_rawDescGZIP(), []int{12}
+	return file_example_app_order_v1_order_v1_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *Created) GetId() string {
@@ -990,7 +1166,7 @@ type ItemAdded struct {
 
 func (x *ItemAdded) Reset() {
 	*x = ItemAdded{}
-	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[13]
+	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1002,7 +1178,7 @@ func (x *ItemAdded) String() string {
 func (*ItemAdded) ProtoMessage() {}
 
 func (x *ItemAdded) ProtoReflect() protoreflect.Message {
-	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[13]
+	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1015,7 +1191,7 @@ func (x *ItemAdded) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ItemAdded.ProtoReflect.Descriptor instead.
 func (*ItemAdded) Descriptor() ([]byte, []int) {
-	return file_example_app_order_v1_order_v1_proto_rawDescGZIP(), []int{13}
+	return file_example_app_order_v1_order_v1_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *ItemAdded) GetId() string {
@@ -1066,7 +1242,7 @@ type ItemRemoved struct {
 
 func (x *ItemRemoved) Reset() {
 	*x = ItemRemoved{}
-	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[14]
+	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1078,7 +1254,7 @@ func (x *ItemRemoved) String() string {
 func (*ItemRemoved) ProtoMessage() {}
 
 func (x *ItemRemoved) ProtoReflect() protoreflect.Message {
-	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[14]
+	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1091,7 +1267,7 @@ func (x *ItemRemoved) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ItemRemoved.ProtoReflect.Descriptor instead.
 func (*ItemRemoved) Descriptor() ([]byte, []int) {
-	return file_example_app_order_v1_order_v1_proto_rawDescGZIP(), []int{14}
+	return file_example_app_order_v1_order_v1_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *ItemRemoved) GetId() string {
@@ -1142,7 +1318,7 @@ type TagAdded struct {
 
 func (x *TagAdded) Reset() {
 	*x = TagAdded{}
-	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[15]
+	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1154,7 +1330,7 @@ func (x *TagAdded) String() string {
 func (*TagAdded) ProtoMessage() {}
 
 func (x *TagAdded) ProtoReflect() protoreflect.Message {
-	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[15]
+	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1167,7 +1343,7 @@ func (x *TagAdded) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TagAdded.ProtoReflect.Descriptor instead.
 func (*TagAdded) Descriptor() ([]byte, []int) {
-	return file_example_app_order_v1_order_v1_proto_rawDescGZIP(), []int{15}
+	return file_example_app_order_v1_order_v1_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *TagAdded) GetId() string {
@@ -1218,7 +1394,7 @@ type TagRemoved struct {
 
 func (x *TagRemoved) Reset() {
 	*x = TagRemoved{}
-	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[16]
+	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1230,7 +1406,7 @@ func (x *TagRemoved) String() string {
 func (*TagRemoved) ProtoMessage() {}
 
 func (x *TagRemoved) ProtoReflect() protoreflect.Message {
-	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[16]
+	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1243,7 +1419,7 @@ func (x *TagRemoved) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TagRemoved.ProtoReflect.Descriptor instead.
 func (*TagRemoved) Descriptor() ([]byte, []int) {
-	return file_example_app_order_v1_order_v1_proto_rawDescGZIP(), []int{16}
+	return file_example_app_order_v1_order_v1_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *TagRemoved) GetId() string {
@@ -1294,7 +1470,7 @@ type ShippingSet struct {
 
 func (x *ShippingSet) Reset() {
 	*x = ShippingSet{}
-	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[17]
+	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1306,7 +1482,7 @@ func (x *ShippingSet) String() string {
 func (*ShippingSet) ProtoMessage() {}
 
 func (x *ShippingSet) ProtoReflect() protoreflect.Message {
-	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[17]
+	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1319,7 +1495,7 @@ func (x *ShippingSet) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ShippingSet.ProtoReflect.Descriptor instead.
 func (*ShippingSet) Descriptor() ([]byte, []int) {
-	return file_example_app_order_v1_order_v1_proto_rawDescGZIP(), []int{17}
+	return file_example_app_order_v1_order_v1_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *ShippingSet) GetId() string {
@@ -1357,6 +1533,162 @@ func (x *ShippingSet) GetShippingAddress() string {
 	return ""
 }
 
+// BillingSet carries a populated "billing" embed; On() copies it into
+// Order.billing by name (no annotation, no inference).
+type BillingSet struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Version       int64                  `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty"`
+	At            int64                  `protobuf:"varint,3,opt,name=at,proto3" json:"at,omitempty"`
+	Actor         string                 `protobuf:"bytes,4,opt,name=actor,proto3" json:"actor,omitempty"`
+	Billing       *Billing               `protobuf:"bytes,5,opt,name=billing,proto3" json:"billing,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BillingSet) Reset() {
+	*x = BillingSet{}
+	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[21]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BillingSet) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BillingSet) ProtoMessage() {}
+
+func (x *BillingSet) ProtoReflect() protoreflect.Message {
+	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[21]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BillingSet.ProtoReflect.Descriptor instead.
+func (*BillingSet) Descriptor() ([]byte, []int) {
+	return file_example_app_order_v1_order_v1_proto_rawDescGZIP(), []int{21}
+}
+
+func (x *BillingSet) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *BillingSet) GetVersion() int64 {
+	if x != nil {
+		return x.Version
+	}
+	return 0
+}
+
+func (x *BillingSet) GetAt() int64 {
+	if x != nil {
+		return x.At
+	}
+	return 0
+}
+
+func (x *BillingSet) GetActor() string {
+	if x != nil {
+		return x.Actor
+	}
+	return ""
+}
+
+func (x *BillingSet) GetBilling() *Billing {
+	if x != nil {
+		return x.Billing
+	}
+	return nil
+}
+
+// BillingCleared carries an empty same-named "billing" embed; the unconditional
+// by-name copy in On() resolves it to nil, clearing Order.billing.
+type BillingCleared struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Version       int64                  `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty"`
+	At            int64                  `protobuf:"varint,3,opt,name=at,proto3" json:"at,omitempty"`
+	Actor         string                 `protobuf:"bytes,4,opt,name=actor,proto3" json:"actor,omitempty"`
+	Billing       *Billing               `protobuf:"bytes,5,opt,name=billing,proto3" json:"billing,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BillingCleared) Reset() {
+	*x = BillingCleared{}
+	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[22]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BillingCleared) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BillingCleared) ProtoMessage() {}
+
+func (x *BillingCleared) ProtoReflect() protoreflect.Message {
+	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[22]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BillingCleared.ProtoReflect.Descriptor instead.
+func (*BillingCleared) Descriptor() ([]byte, []int) {
+	return file_example_app_order_v1_order_v1_proto_rawDescGZIP(), []int{22}
+}
+
+func (x *BillingCleared) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *BillingCleared) GetVersion() int64 {
+	if x != nil {
+		return x.Version
+	}
+	return 0
+}
+
+func (x *BillingCleared) GetAt() int64 {
+	if x != nil {
+		return x.At
+	}
+	return 0
+}
+
+func (x *BillingCleared) GetActor() string {
+	if x != nil {
+		return x.Actor
+	}
+	return ""
+}
+
+func (x *BillingCleared) GetBilling() *Billing {
+	if x != nil {
+		return x.Billing
+	}
+	return nil
+}
+
 type Placed struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
@@ -1370,7 +1702,7 @@ type Placed struct {
 
 func (x *Placed) Reset() {
 	*x = Placed{}
-	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[18]
+	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1382,7 +1714,7 @@ func (x *Placed) String() string {
 func (*Placed) ProtoMessage() {}
 
 func (x *Placed) ProtoReflect() protoreflect.Message {
-	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[18]
+	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1395,7 +1727,7 @@ func (x *Placed) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Placed.ProtoReflect.Descriptor instead.
 func (*Placed) Descriptor() ([]byte, []int) {
-	return file_example_app_order_v1_order_v1_proto_rawDescGZIP(), []int{18}
+	return file_example_app_order_v1_order_v1_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *Placed) GetId() string {
@@ -1446,7 +1778,7 @@ type Cancelled struct {
 
 func (x *Cancelled) Reset() {
 	*x = Cancelled{}
-	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[19]
+	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1458,7 +1790,7 @@ func (x *Cancelled) String() string {
 func (*Cancelled) ProtoMessage() {}
 
 func (x *Cancelled) ProtoReflect() protoreflect.Message {
-	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[19]
+	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1471,7 +1803,7 @@ func (x *Cancelled) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Cancelled.ProtoReflect.Descriptor instead.
 func (*Cancelled) Descriptor() ([]byte, []int) {
-	return file_example_app_order_v1_order_v1_proto_rawDescGZIP(), []int{19}
+	return file_example_app_order_v1_order_v1_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *Cancelled) GetId() string {
@@ -1529,7 +1861,7 @@ type OrderSummary struct {
 
 func (x *OrderSummary) Reset() {
 	*x = OrderSummary{}
-	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[20]
+	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1541,7 +1873,7 @@ func (x *OrderSummary) String() string {
 func (*OrderSummary) ProtoMessage() {}
 
 func (x *OrderSummary) ProtoReflect() protoreflect.Message {
-	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[20]
+	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1554,7 +1886,7 @@ func (x *OrderSummary) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OrderSummary.ProtoReflect.Descriptor instead.
 func (*OrderSummary) Descriptor() ([]byte, []int) {
-	return file_example_app_order_v1_order_v1_proto_rawDescGZIP(), []int{20}
+	return file_example_app_order_v1_order_v1_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *OrderSummary) GetId() string {
@@ -1626,7 +1958,7 @@ type Snapshot struct {
 
 func (x *Snapshot) Reset() {
 	*x = Snapshot{}
-	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[21]
+	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1638,7 +1970,7 @@ func (x *Snapshot) String() string {
 func (*Snapshot) ProtoMessage() {}
 
 func (x *Snapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[21]
+	mi := &file_example_app_order_v1_order_v1_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1651,7 +1983,7 @@ func (x *Snapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Snapshot.ProtoReflect.Descriptor instead.
 func (*Snapshot) Descriptor() ([]byte, []int) {
-	return file_example_app_order_v1_order_v1_proto_rawDescGZIP(), []int{21}
+	return file_example_app_order_v1_order_v1_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *Snapshot) GetId() string {
@@ -1693,7 +2025,7 @@ var File_example_app_order_v1_order_v1_proto protoreflect.FileDescriptor
 
 const file_example_app_order_v1_order_v1_proto_rawDesc = "" +
 	"\n" +
-	"#example/app/order/v1/order_v1.proto\x12\x14example.app.order.v1\x1a5funinthecloud/protosource/options/v1/options_v1.proto\"\xe8\x05\n" +
+	"#example/app/order/v1/order_v1.proto\x12\x14example.app.order.v1\x1a5funinthecloud/protosource/options/v1/options_v1.proto\"\xa1\x06\n" +
 	"\x05Order\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x18\n" +
 	"\aversion\x18\x02 \x01(\x03R\aversion\x121\n" +
@@ -1715,7 +2047,8 @@ const file_example_app_order_v1_order_v1_proto_rawDesc = "" +
 	"\x10shipping_address\x18\f \x01(\tR\x0fshippingAddress\x12\x1b\n" +
 	"\tplaced_at\x18\r \x01(\x03R\bplacedAt\x12<\n" +
 	"\x05items\x18\x0e \x03(\v2&.example.app.order.v1.Order.ItemsEntryR\x05items\x129\n" +
-	"\x04tags\x18\x0f \x03(\v2%.example.app.order.v1.Order.TagsEntryR\x04tags\x1aX\n" +
+	"\x04tags\x18\x0f \x03(\v2%.example.app.order.v1.Order.TagsEntryR\x04tags\x127\n" +
+	"\abilling\x18\x10 \x01(\v2\x1d.example.app.order.v1.BillingR\abilling\x1aX\n" +
 	"\n" +
 	"ItemsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x124\n" +
@@ -1733,7 +2066,10 @@ const file_example_app_order_v1_order_v1_proto_rawDesc = "" +
 	"\bquantity\x18\x04 \x01(\x05R\bquantity\"-\n" +
 	"\x03Tag\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value\"\x86\x01\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value\"?\n" +
+	"\aBilling\x12\x16\n" +
+	"\x06method\x18\x01 \x01(\tR\x06method\x12\x1c\n" +
+	"\treference\x18\x02 \x01(\tR\treference\"\x86\x01\n" +
 	"\x06Create\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x14\n" +
 	"\x05actor\x18\x02 \x01(\tR\x05actor\x12\x1f\n" +
@@ -1773,7 +2109,20 @@ const file_example_app_order_v1_order_v1_proto_rawDesc = "" +
 	"\x05actor\x18\x02 \x01(\tR\x05actor\x12)\n" +
 	"\x10shipping_address\x18\x03 \x01(\tR\x0fshippingAddress:!\x8aQ\x1e\n" +
 	"\x1c\n" +
-	"\vShippingSet\x10\x02\x1a\vSTATE_DRAFT\"h\n" +
+	"\vShippingSet\x10\x02\x1a\vSTATE_DRAFT\"\x80\x01\n" +
+	"\n" +
+	"SetBilling\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x14\n" +
+	"\x05actor\x18\x02 \x01(\tR\x05actor\x127\n" +
+	"\abilling\x18\x03 \x01(\v2\x1d.example.app.order.v1.BillingR\abilling:\x13\x8aQ\x10\n" +
+	"\x0e\n" +
+	"\n" +
+	"BillingSet\x10\x02\"M\n" +
+	"\fClearBilling\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x14\n" +
+	"\x05actor\x18\x02 \x01(\tR\x05actor:\x17\x8aQ\x14\n" +
+	"\x12\n" +
+	"\x0eBillingCleared\x10\x02\"h\n" +
 	"\x05Place\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x14\n" +
 	"\x05actor\x18\x02 \x01(\tR\x05actor\x12\x1b\n" +
@@ -1829,7 +2178,20 @@ const file_example_app_order_v1_order_v1_proto_rawDesc = "" +
 	"\aversion\x18\x02 \x01(\x03R\aversion\x12\x0e\n" +
 	"\x02at\x18\x03 \x01(\x03R\x02at\x12\x14\n" +
 	"\x05actor\x18\x04 \x01(\tR\x05actor\x12)\n" +
-	"\x10shipping_address\x18\x05 \x01(\tR\x0fshippingAddress:\x05\x8aQ\x02\x12\x00\"\x8a\x01\n" +
+	"\x10shipping_address\x18\x05 \x01(\tR\x0fshippingAddress:\x05\x8aQ\x02\x12\x00\"\x9c\x01\n" +
+	"\n" +
+	"BillingSet\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x18\n" +
+	"\aversion\x18\x02 \x01(\x03R\aversion\x12\x0e\n" +
+	"\x02at\x18\x03 \x01(\x03R\x02at\x12\x14\n" +
+	"\x05actor\x18\x04 \x01(\tR\x05actor\x127\n" +
+	"\abilling\x18\x05 \x01(\v2\x1d.example.app.order.v1.BillingR\abilling:\x05\x8aQ\x02\x12\x00\"\xa0\x01\n" +
+	"\x0eBillingCleared\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x18\n" +
+	"\aversion\x18\x02 \x01(\x03R\aversion\x12\x0e\n" +
+	"\x02at\x18\x03 \x01(\x03R\x02at\x12\x14\n" +
+	"\x05actor\x18\x04 \x01(\tR\x05actor\x127\n" +
+	"\abilling\x18\x05 \x01(\v2\x1d.example.app.order.v1.BillingR\abilling:\x05\x8aQ\x02\x12\x00\"\x8a\x01\n" +
 	"\x06Placed\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x18\n" +
 	"\aversion\x18\x02 \x01(\x03R\aversion\x12\x0e\n" +
@@ -1888,52 +2250,61 @@ func file_example_app_order_v1_order_v1_proto_rawDescGZIP() []byte {
 }
 
 var file_example_app_order_v1_order_v1_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_example_app_order_v1_order_v1_proto_msgTypes = make([]protoimpl.MessageInfo, 24)
+var file_example_app_order_v1_order_v1_proto_msgTypes = make([]protoimpl.MessageInfo, 29)
 var file_example_app_order_v1_order_v1_proto_goTypes = []any{
-	(State)(0),           // 0: example.app.order.v1.State
-	(*Order)(nil),        // 1: example.app.order.v1.Order
-	(*OrderList)(nil),    // 2: example.app.order.v1.OrderList
-	(*LineItem)(nil),     // 3: example.app.order.v1.LineItem
-	(*Tag)(nil),          // 4: example.app.order.v1.Tag
-	(*Create)(nil),       // 5: example.app.order.v1.Create
-	(*AddItem)(nil),      // 6: example.app.order.v1.AddItem
-	(*RemoveItem)(nil),   // 7: example.app.order.v1.RemoveItem
-	(*AddTag)(nil),       // 8: example.app.order.v1.AddTag
-	(*RemoveTag)(nil),    // 9: example.app.order.v1.RemoveTag
-	(*SetShipping)(nil),  // 10: example.app.order.v1.SetShipping
-	(*Place)(nil),        // 11: example.app.order.v1.Place
-	(*Cancel)(nil),       // 12: example.app.order.v1.Cancel
-	(*Created)(nil),      // 13: example.app.order.v1.Created
-	(*ItemAdded)(nil),    // 14: example.app.order.v1.ItemAdded
-	(*ItemRemoved)(nil),  // 15: example.app.order.v1.ItemRemoved
-	(*TagAdded)(nil),     // 16: example.app.order.v1.TagAdded
-	(*TagRemoved)(nil),   // 17: example.app.order.v1.TagRemoved
-	(*ShippingSet)(nil),  // 18: example.app.order.v1.ShippingSet
-	(*Placed)(nil),       // 19: example.app.order.v1.Placed
-	(*Cancelled)(nil),    // 20: example.app.order.v1.Cancelled
-	(*OrderSummary)(nil), // 21: example.app.order.v1.OrderSummary
-	(*Snapshot)(nil),     // 22: example.app.order.v1.Snapshot
-	nil,                  // 23: example.app.order.v1.Order.ItemsEntry
-	nil,                  // 24: example.app.order.v1.Order.TagsEntry
+	(State)(0),             // 0: example.app.order.v1.State
+	(*Order)(nil),          // 1: example.app.order.v1.Order
+	(*OrderList)(nil),      // 2: example.app.order.v1.OrderList
+	(*LineItem)(nil),       // 3: example.app.order.v1.LineItem
+	(*Tag)(nil),            // 4: example.app.order.v1.Tag
+	(*Billing)(nil),        // 5: example.app.order.v1.Billing
+	(*Create)(nil),         // 6: example.app.order.v1.Create
+	(*AddItem)(nil),        // 7: example.app.order.v1.AddItem
+	(*RemoveItem)(nil),     // 8: example.app.order.v1.RemoveItem
+	(*AddTag)(nil),         // 9: example.app.order.v1.AddTag
+	(*RemoveTag)(nil),      // 10: example.app.order.v1.RemoveTag
+	(*SetShipping)(nil),    // 11: example.app.order.v1.SetShipping
+	(*SetBilling)(nil),     // 12: example.app.order.v1.SetBilling
+	(*ClearBilling)(nil),   // 13: example.app.order.v1.ClearBilling
+	(*Place)(nil),          // 14: example.app.order.v1.Place
+	(*Cancel)(nil),         // 15: example.app.order.v1.Cancel
+	(*Created)(nil),        // 16: example.app.order.v1.Created
+	(*ItemAdded)(nil),      // 17: example.app.order.v1.ItemAdded
+	(*ItemRemoved)(nil),    // 18: example.app.order.v1.ItemRemoved
+	(*TagAdded)(nil),       // 19: example.app.order.v1.TagAdded
+	(*TagRemoved)(nil),     // 20: example.app.order.v1.TagRemoved
+	(*ShippingSet)(nil),    // 21: example.app.order.v1.ShippingSet
+	(*BillingSet)(nil),     // 22: example.app.order.v1.BillingSet
+	(*BillingCleared)(nil), // 23: example.app.order.v1.BillingCleared
+	(*Placed)(nil),         // 24: example.app.order.v1.Placed
+	(*Cancelled)(nil),      // 25: example.app.order.v1.Cancelled
+	(*OrderSummary)(nil),   // 26: example.app.order.v1.OrderSummary
+	(*Snapshot)(nil),       // 27: example.app.order.v1.Snapshot
+	nil,                    // 28: example.app.order.v1.Order.ItemsEntry
+	nil,                    // 29: example.app.order.v1.Order.TagsEntry
 }
 var file_example_app_order_v1_order_v1_proto_depIdxs = []int32{
 	0,  // 0: example.app.order.v1.Order.state:type_name -> example.app.order.v1.State
-	23, // 1: example.app.order.v1.Order.items:type_name -> example.app.order.v1.Order.ItemsEntry
-	24, // 2: example.app.order.v1.Order.tags:type_name -> example.app.order.v1.Order.TagsEntry
-	1,  // 3: example.app.order.v1.OrderList.items:type_name -> example.app.order.v1.Order
-	3,  // 4: example.app.order.v1.AddItem.item:type_name -> example.app.order.v1.LineItem
-	4,  // 5: example.app.order.v1.AddTag.tag:type_name -> example.app.order.v1.Tag
-	3,  // 6: example.app.order.v1.ItemAdded.item:type_name -> example.app.order.v1.LineItem
-	4,  // 7: example.app.order.v1.TagAdded.tag:type_name -> example.app.order.v1.Tag
-	0,  // 8: example.app.order.v1.OrderSummary.state:type_name -> example.app.order.v1.State
-	1,  // 9: example.app.order.v1.Snapshot.snapshot:type_name -> example.app.order.v1.Order
-	3,  // 10: example.app.order.v1.Order.ItemsEntry.value:type_name -> example.app.order.v1.LineItem
-	4,  // 11: example.app.order.v1.Order.TagsEntry.value:type_name -> example.app.order.v1.Tag
-	12, // [12:12] is the sub-list for method output_type
-	12, // [12:12] is the sub-list for method input_type
-	12, // [12:12] is the sub-list for extension type_name
-	12, // [12:12] is the sub-list for extension extendee
-	0,  // [0:12] is the sub-list for field type_name
+	28, // 1: example.app.order.v1.Order.items:type_name -> example.app.order.v1.Order.ItemsEntry
+	29, // 2: example.app.order.v1.Order.tags:type_name -> example.app.order.v1.Order.TagsEntry
+	5,  // 3: example.app.order.v1.Order.billing:type_name -> example.app.order.v1.Billing
+	1,  // 4: example.app.order.v1.OrderList.items:type_name -> example.app.order.v1.Order
+	3,  // 5: example.app.order.v1.AddItem.item:type_name -> example.app.order.v1.LineItem
+	4,  // 6: example.app.order.v1.AddTag.tag:type_name -> example.app.order.v1.Tag
+	5,  // 7: example.app.order.v1.SetBilling.billing:type_name -> example.app.order.v1.Billing
+	3,  // 8: example.app.order.v1.ItemAdded.item:type_name -> example.app.order.v1.LineItem
+	4,  // 9: example.app.order.v1.TagAdded.tag:type_name -> example.app.order.v1.Tag
+	5,  // 10: example.app.order.v1.BillingSet.billing:type_name -> example.app.order.v1.Billing
+	5,  // 11: example.app.order.v1.BillingCleared.billing:type_name -> example.app.order.v1.Billing
+	0,  // 12: example.app.order.v1.OrderSummary.state:type_name -> example.app.order.v1.State
+	1,  // 13: example.app.order.v1.Snapshot.snapshot:type_name -> example.app.order.v1.Order
+	3,  // 14: example.app.order.v1.Order.ItemsEntry.value:type_name -> example.app.order.v1.LineItem
+	4,  // 15: example.app.order.v1.Order.TagsEntry.value:type_name -> example.app.order.v1.Tag
+	16, // [16:16] is the sub-list for method output_type
+	16, // [16:16] is the sub-list for method input_type
+	16, // [16:16] is the sub-list for extension type_name
+	16, // [16:16] is the sub-list for extension extendee
+	0,  // [0:16] is the sub-list for field type_name
 }
 
 func init() { file_example_app_order_v1_order_v1_proto_init() }
@@ -1947,7 +2318,7 @@ func file_example_app_order_v1_order_v1_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_example_app_order_v1_order_v1_proto_rawDesc), len(file_example_app_order_v1_order_v1_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   24,
+			NumMessages:   29,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/gen/example/app/order/v1/order_v1.protosource.client.pb.go
+++ b/gen/example/app/order/v1/order_v1.protosource.client.pb.go
@@ -81,6 +81,23 @@ func (c *HTTPClient) SetShipping(ctx context.Context, id string, shippingAddress
 	return c.c.Apply(ctx, routePath, cmd)
 }
 
+// SetBilling sends the SetBilling command.
+func (c *HTTPClient) SetBilling(ctx context.Context, id string, billing *Billing) (responsev1.Responseer, error) {
+	cmd := &SetBilling{
+		Id:      id,
+		Billing: billing,
+	}
+	return c.c.Apply(ctx, routePath, cmd)
+}
+
+// ClearBilling sends the ClearBilling command.
+func (c *HTTPClient) ClearBilling(ctx context.Context, id string) (responsev1.Responseer, error) {
+	cmd := &ClearBilling{
+		Id: id,
+	}
+	return c.c.Apply(ctx, routePath, cmd)
+}
+
 // Place sends the Place command.
 func (c *HTTPClient) Place(ctx context.Context, id string, placedAt int64) (responsev1.Responseer, error) {
 	cmd := &Place{

--- a/gen/example/app/order/v1/order_v1.protosource.lambda.pb.go
+++ b/gen/example/app/order/v1/order_v1.protosource.lambda.pb.go
@@ -65,6 +65,8 @@ func (h *Handler) RegisterRoutes(router *protosource.Router) {
 	router.Handle("POST", "example/app/order/v1/addtag", h.HandleAddTag)
 	router.Handle("POST", "example/app/order/v1/removetag", h.HandleRemoveTag)
 	router.Handle("POST", "example/app/order/v1/setshipping", h.HandleSetShipping)
+	router.Handle("POST", "example/app/order/v1/setbilling", h.HandleSetBilling)
+	router.Handle("POST", "example/app/order/v1/clearbilling", h.HandleClearBilling)
 	router.Handle("POST", "example/app/order/v1/place", h.HandlePlace)
 	router.Handle("POST", "example/app/order/v1/cancel", h.HandleCancel)
 	router.Handle("GET", "example/app/order/v1/load/{id}", h.HandleLoad)
@@ -292,6 +294,88 @@ func (h *Handler) HandleSetShipping(ctx context.Context, request protosource.Req
 	}
 
 	cmd := &SetShipping{}
+	if err := unmarshalCommand(request, cmd); err != nil {
+		return errorResponse(request, http.StatusBadRequest, "CMD_UNMARSHAL", "invalid request body", err)
+	}
+
+	// Overwrite any Actor the client supplied in the command payload
+	// with the identity resolved above.
+	// Never trust an actor field coming from the wire
+	// — it would let any caller spoof any identity.
+	cmd.Actor = actor
+
+	version, err := h.repo.Apply(ctx, cmd)
+	if err != nil {
+		return commandErrorResponse(request, err)
+	}
+
+	resp := &responsev1.CommandResponse{Id: cmd.GetId(), Version: version}
+	body, contentType, err := marshalResponse(request, resp)
+	if err != nil {
+		return errorResponse(request, http.StatusInternalServerError, "CMD_MARSHAL", "failed to serialize response", err)
+	}
+	return protosource.Response{
+		StatusCode: http.StatusOK,
+		Body:       string(body),
+		Headers:    map[string]string{"Content-Type": contentType},
+	}
+}
+
+// HandleSetBilling processes a SetBilling command.
+func (h *Handler) HandleSetBilling(ctx context.Context, request protosource.Request) protosource.Response {
+	ctx, err := h.authorizer.Authorize(ctx, request, "example.app.order.v1.SetBilling")
+	if err != nil {
+		return authzErrorResponse(request, err)
+	}
+
+	// Actor must be extracted by the Authorizer and put into ctx.
+	actor := authz.UserIDFromContext(ctx)
+	if actor == "" {
+		return errorResponse(request, http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
+	}
+
+	cmd := &SetBilling{}
+	if err := unmarshalCommand(request, cmd); err != nil {
+		return errorResponse(request, http.StatusBadRequest, "CMD_UNMARSHAL", "invalid request body", err)
+	}
+
+	// Overwrite any Actor the client supplied in the command payload
+	// with the identity resolved above.
+	// Never trust an actor field coming from the wire
+	// — it would let any caller spoof any identity.
+	cmd.Actor = actor
+
+	version, err := h.repo.Apply(ctx, cmd)
+	if err != nil {
+		return commandErrorResponse(request, err)
+	}
+
+	resp := &responsev1.CommandResponse{Id: cmd.GetId(), Version: version}
+	body, contentType, err := marshalResponse(request, resp)
+	if err != nil {
+		return errorResponse(request, http.StatusInternalServerError, "CMD_MARSHAL", "failed to serialize response", err)
+	}
+	return protosource.Response{
+		StatusCode: http.StatusOK,
+		Body:       string(body),
+		Headers:    map[string]string{"Content-Type": contentType},
+	}
+}
+
+// HandleClearBilling processes a ClearBilling command.
+func (h *Handler) HandleClearBilling(ctx context.Context, request protosource.Request) protosource.Response {
+	ctx, err := h.authorizer.Authorize(ctx, request, "example.app.order.v1.ClearBilling")
+	if err != nil {
+		return authzErrorResponse(request, err)
+	}
+
+	// Actor must be extracted by the Authorizer and put into ctx.
+	actor := authz.UserIDFromContext(ctx)
+	if actor == "" {
+		return errorResponse(request, http.StatusUnauthorized, "CMD_NO_ACTOR", "no actor identity found", nil)
+	}
+
+	cmd := &ClearBilling{}
 	if err := unmarshalCommand(request, cmd); err != nil {
 		return errorResponse(request, http.StatusBadRequest, "CMD_UNMARSHAL", "invalid request body", err)
 	}

--- a/gen/example/app/order/v1/order_v1.protosource.pb.go
+++ b/gen/example/app/order/v1/order_v1.protosource.pb.go
@@ -83,6 +83,7 @@ func (aggregate *Order) RestoreSnapshot(snapshot *Snapshot) {
 	aggregate.PlacedAt = snapshot.GetSnapshot().GetPlacedAt()
 	aggregate.Items = snapshot.GetSnapshot().GetItems()
 	aggregate.Tags = snapshot.GetSnapshot().GetTags()
+	aggregate.Billing = snapshot.GetSnapshot().GetBilling()
 	aggregate.Version = snapshot.GetVersion()
 }
 func (b *Builder) Snapshot(aggregate *Order) {
@@ -148,6 +149,12 @@ func (aggregate *Order) On(event protosource.Event) error {
 	case *ShippingSet:
 		aggregate.setModified(e)
 		aggregate.ShippingAddress = e.GetShippingAddress()
+	case *BillingSet:
+		aggregate.setModified(e)
+		aggregate.Billing = e.GetBilling()
+	case *BillingCleared:
+		aggregate.setModified(e)
+		aggregate.Billing = e.GetBilling()
 	case *Placed:
 		aggregate.setModified(e)
 		aggregate.PlacedAt = e.GetPlacedAt()
@@ -567,6 +574,58 @@ func (m *SetShipping) EmitEvents(aggregate protosource.Aggregate) []protosource.
 	return b.Events
 }
 
+func (m *SetBilling) CommandName() string {
+	return "SetBilling"
+}
+
+func (m *SetBilling) ProtoValidate() error {
+	if err := validator().Validate(m); err != nil {
+		return fmt.Errorf("command %s: %w: %w", m.CommandName(), protosource.ErrValidationFailed, err)
+	}
+	return nil
+}
+
+func (m *SetBilling) ValidateVersion(version int64) error {
+	if version == 0 {
+		return fmt.Errorf("command %s requires an existing aggregate (version > 0), got version 0: %w", m.CommandName(), protosource.ErrNotCreatedYet)
+	}
+	return nil
+}
+func (m *SetBilling) EmitEvents(aggregate protosource.Aggregate) []protosource.Event {
+	b := NewBuilder(m.GetId(), aggregate.GetVersion())
+	a := proto.Clone(aggregate).(*Order)
+	b.BillingSet(m.GetActor(), m.GetBilling())
+	_ = a.On(b.Events[len(b.Events)-1]) // safe: On only errors on unhandled event types, and we only emit events defined in this file
+	b.Snapshot(a)                       // Snapshot calls AfterOn() internally only when a snapshot is actually emitted
+	return b.Events
+}
+
+func (m *ClearBilling) CommandName() string {
+	return "ClearBilling"
+}
+
+func (m *ClearBilling) ProtoValidate() error {
+	if err := validator().Validate(m); err != nil {
+		return fmt.Errorf("command %s: %w: %w", m.CommandName(), protosource.ErrValidationFailed, err)
+	}
+	return nil
+}
+
+func (m *ClearBilling) ValidateVersion(version int64) error {
+	if version == 0 {
+		return fmt.Errorf("command %s requires an existing aggregate (version > 0), got version 0: %w", m.CommandName(), protosource.ErrNotCreatedYet)
+	}
+	return nil
+}
+func (m *ClearBilling) EmitEvents(aggregate protosource.Aggregate) []protosource.Event {
+	b := NewBuilder(m.GetId(), aggregate.GetVersion())
+	a := proto.Clone(aggregate).(*Order)
+	b.BillingCleared(m.GetActor(), nil)
+	_ = a.On(b.Events[len(b.Events)-1]) // safe: On only errors on unhandled event types, and we only emit events defined in this file
+	b.Snapshot(a)                       // Snapshot calls AfterOn() internally only when a snapshot is actually emitted
+	return b.Events
+}
+
 func (m *Place) CommandName() string {
 	return "Place"
 }
@@ -727,6 +786,38 @@ func (b *Builder) ShippingSet(Actor string, ShippingAddress string) {
 		Id:              b.id,
 		Actor:           Actor,
 		ShippingAddress: ShippingAddress,
+
+		Version: b.nextVersion(),
+		At:      protosource.NowMicros(),
+	}
+	b.Events = append(b.Events, event)
+}
+
+func (m *BillingSet) EventName() string {
+	return "BillingSet"
+}
+
+func (b *Builder) BillingSet(Actor string, Billing *Billing) {
+	event := &BillingSet{
+		Id:      b.id,
+		Actor:   Actor,
+		Billing: Billing,
+
+		Version: b.nextVersion(),
+		At:      protosource.NowMicros(),
+	}
+	b.Events = append(b.Events, event)
+}
+
+func (m *BillingCleared) EventName() string {
+	return "BillingCleared"
+}
+
+func (b *Builder) BillingCleared(Actor string, Billing *Billing) {
+	event := &BillingCleared{
+		Id:      b.id,
+		Actor:   Actor,
+		Billing: Billing,
 
 		Version: b.nextVersion(),
 		At:      protosource.NowMicros(),

--- a/gen/example/app/order/v1/ordermgr/main.go
+++ b/gen/example/app/order/v1/ordermgr/main.go
@@ -26,6 +26,8 @@ var usage = "Usage: ordermgr [-json] <command> [args]\n\nFlags:\n" +
 	"  addtag  <id>  <tag:json>\n" +
 	"  removetag  <id>  <key>\n" +
 	"  setshipping  <id>  <shipping_address>\n" +
+	"  setbilling  <id>  <billing:json>\n" +
+	"  clearbilling  <id>\n" +
 	"  place  <id>  <placed_at>\n" +
 	"  cancel  <id>  <reason>\n" +
 	"  get      <id>\n" +
@@ -135,6 +137,26 @@ func main() {
 			fatal("usage: ordermgr setshipping <id> <shipping_address>")
 		}
 		result, err := client.SetShipping(ctx, os.Args[2], os.Args[3])
+		if err != nil {
+			fatal(fmt.Sprintf("error: %v", err))
+		}
+		fmt.Printf("{\"id\":%q,\"version\":%d}\n", result.GetId(), result.GetVersion())
+
+	case "setbilling":
+		if len(os.Args) != 4 {
+			fatal("usage: ordermgr setbilling <id> <billing:json>")
+		}
+		result, err := client.SetBilling(ctx, os.Args[2], mustParseJSON[*pkg.Billing](os.Args[3], "billing"))
+		if err != nil {
+			fatal(fmt.Sprintf("error: %v", err))
+		}
+		fmt.Printf("{\"id\":%q,\"version\":%d}\n", result.GetId(), result.GetVersion())
+
+	case "clearbilling":
+		if len(os.Args) != 3 {
+			fatal("usage: ordermgr clearbilling <id>")
+		}
+		result, err := client.ClearBilling(ctx, os.Args[2])
 		if err != nil {
 			fatal(fmt.Sprintf("error: %v", err))
 		}

--- a/proto/example/app/order/v1/order_v1.proto
+++ b/proto/example/app/order/v1/order_v1.proto
@@ -63,7 +63,8 @@ message Tag {
 // Billing is a singular embedded value object on the Order. It is set and
 // cleared by the by-name convention (no annotation): the BillingSet/
 // BillingCleared events carry a field literally named "billing", which On()
-// copies into Order.billing — populated to set, empty to clear.
+// copies into Order.billing — populated to set, unset (nil) to clear. Note a
+// present-but-empty &Billing{} is non-nil and would NOT clear.
 message Billing {
   string method    = 1;  // e.g. "card", "invoice"
   string reference = 2;  // opaque payment reference
@@ -263,8 +264,10 @@ message BillingSet {
   Billing billing = 5;
 }
 
-// BillingCleared carries an empty same-named "billing" embed; the unconditional
-// by-name copy in On() resolves it to nil, clearing Order.billing.
+// BillingCleared declares a same-named "billing" embed but emits it unset (the
+// ClearBilling command carries no billing, so EmitEvents passes nil). On()'s
+// unconditional by-name copy then assigns nil, clearing Order.billing. The field
+// must be unset (nil) to clear — a present-but-empty &Billing{} would not.
 message BillingCleared {
   option (funinthecloud.protosource.options.v1.protosource_message_type).event = {
   };

--- a/proto/example/app/order/v1/order_v1.proto
+++ b/proto/example/app/order/v1/order_v1.proto
@@ -4,6 +4,7 @@ package example.app.order.v1;
 
 option go_package = "github.com/funinthecloud/protosource/gen/example/app/order/v1;orderv1";
 
+import "buf/validate/validate.proto";
 import "funinthecloud/protosource/options/v1/options_v1.proto";
 
 option (funinthecloud.protosource.options.v1.protosource_file).enabled = true;
@@ -143,9 +144,14 @@ message SetBilling {
     produces_events: [ "BillingSet" ]
     lifecycle: COMMAND_LIFECYCLE_MUTATION
   };
-  string  id      = 1;
-  string  actor   = 2;
-  Billing billing = 3;
+  string id    = 1;
+  string actor = 2;
+  // required: SetBilling must carry a populated embed. Without this, a
+  // SetBilling with billing unset would pass ProtoValidate and emit
+  // BillingSet{billing=nil}, which On() copies — silently clearing
+  // Order.billing under a "set" event. Clearing is the explicit ClearBilling
+  // command's job. See docs/decisions/0001-singular-embedded-messages-by-name.md.
+  Billing billing = 3 [(buf.validate.field).required = true];
 }
 
 message ClearBilling {

--- a/proto/example/app/order/v1/order_v1.proto
+++ b/proto/example/app/order/v1/order_v1.proto
@@ -39,6 +39,7 @@ message Order {
   int64                 placed_at        = 13;
   map<string, LineItem> items            = 14;
   map<string, Tag>      tags             = 15;
+  Billing               billing          = 16;
 }
 
 message OrderList {
@@ -57,6 +58,15 @@ message LineItem {
 message Tag {
   string key   = 1;
   string value = 2;
+}
+
+// Billing is a singular embedded value object on the Order. It is set and
+// cleared by the by-name convention (no annotation): the BillingSet/
+// BillingCleared events carry a field literally named "billing", which On()
+// copies into Order.billing — populated to set, empty to clear.
+message Billing {
+  string method    = 1;  // e.g. "card", "invoice"
+  string reference = 2;  // opaque payment reference
 }
 
 // ── Commands ──
@@ -125,6 +135,25 @@ message SetShipping {
   string id               = 1;
   string actor            = 2;
   string shipping_address = 3;
+}
+
+message SetBilling {
+  option (funinthecloud.protosource.options.v1.protosource_message_type).command = {
+    produces_events: [ "BillingSet" ]
+    lifecycle: COMMAND_LIFECYCLE_MUTATION
+  };
+  string  id      = 1;
+  string  actor   = 2;
+  Billing billing = 3;
+}
+
+message ClearBilling {
+  option (funinthecloud.protosource.options.v1.protosource_message_type).command = {
+    produces_events: [ "BillingCleared" ]
+    lifecycle: COMMAND_LIFECYCLE_MUTATION
+  };
+  string id    = 1;
+  string actor = 2;
 }
 
 message Place {
@@ -220,6 +249,30 @@ message ShippingSet {
   int64  at               = 3;
   string actor            = 4;
   string shipping_address = 5;
+}
+
+// BillingSet carries a populated "billing" embed; On() copies it into
+// Order.billing by name (no annotation, no inference).
+message BillingSet {
+  option (funinthecloud.protosource.options.v1.protosource_message_type).event = {
+  };
+  string  id      = 1;
+  int64   version = 2;
+  int64   at      = 3;
+  string  actor   = 4;
+  Billing billing = 5;
+}
+
+// BillingCleared carries an empty same-named "billing" embed; the unconditional
+// by-name copy in On() resolves it to nil, clearing Order.billing.
+message BillingCleared {
+  option (funinthecloud.protosource.options.v1.protosource_message_type).event = {
+  };
+  string  id      = 1;
+  int64   version = 2;
+  int64   at      = 3;
+  string  actor   = 4;
+  Billing billing = 5;
 }
 
 message Placed {


### PR DESCRIPTION
## Summary (revised approach)

Closes the GH#96 gap: a singular (non-collection) embedded message field on an aggregate now gets populated/cleared by generated `On()` with **no hand-patching of generated files**.

**This PR replaces the original type-inference attempt** (force-pushed; the earlier inference commits are gone). An experiment proved the generator's existing **by-name** field copy — the same mechanism used for scalars — already handles a singular embedded message when the event field name matches the aggregate field:

```go
case *ProfileSet:    aggregate.Profile = e.GetProfile()  // populated -> set
case *ProfileCleared: aggregate.Profile = e.GetProfile()  // empty     -> nil (clear)
```

So the feature is a **convention**, not inference: name the event's embed field to match the aggregate field. Set carries the populated message; clear carries the same-named field left empty (the unconditional copy nils it).

### Why not the inference approach
Matching embeds by message **type** (to tolerate a `config` vs `oidc` name divergence) created a real ambiguity class — two aggregate fields of the same type can't be resolved — and emitted a duplicate assignment alongside the scalar copy. By-name matching is consistent with scalars, unambiguous (field names are unique), and needs no annotation or template change.

### Delivered
- `validateSingularEmbed`: **fails codegen** when an event carries an embedded message of a type present on the aggregate but under a different field name (the silent no-op that was the original GH#96 symptom), with a rename hint. Collection events are exempt.
- `testdata/singular_embed_{valid,mismatch}.proto` + tests for the match and mismatch paths.
- `CLAUDE.md`: documents the by-name convention and the validator.

### Verification
- `buf generate` over all existing protos: **zero diff** (no template change, no false positives).
- Full `go build` / `go test ./...` green.

Refs: protosource-5ww, GH#96
