### PR TITLE
feat: support multiple Set-Cookie headers in Response (GH#103)

### DIFF
--- a/adapters/awslambda/adapter.go
+++ b/adapters/awslambda/adapter.go
@@ -108,6 +108,22 @@ func encodeResponse(resp protosource.Response) events.APIGatewayProxyResponse {
 		StatusCode: resp.StatusCode,
 		Headers:    resp.Headers,
 	}
+	// DECISION: render Cookies via v1 MultiValueHeaders, not v2 Cookies (see docs/decisions/0002-multi-cookie-response-support.md).
+	// REST API Gateway (proxy v1) collapses the single-value Headers map to one
+	// value per key, so multiple Set-Cookie headers must go through
+	// MultiValueHeaders. http.Cookie.String returns "" for an invalid cookie,
+	// which we skip rather than emit a blank header.
+	if len(resp.Cookies) > 0 {
+		var setCookies []string
+		for _, c := range resp.Cookies {
+			if s := c.String(); s != "" {
+				setCookies = append(setCookies, s)
+			}
+		}
+		if len(setCookies) > 0 {
+			apiResp.MultiValueHeaders = map[string][]string{"Set-Cookie": setCookies}
+		}
+	}
 	if isBinary {
 		apiResp.Body = base64.StdEncoding.EncodeToString([]byte(resp.Body))
 		apiResp.IsBase64Encoded = true

--- a/adapters/awslambda/adapter_test.go
+++ b/adapters/awslambda/adapter_test.go
@@ -3,6 +3,7 @@ package awslambda
 import (
 	"context"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-lambda-go/events"
@@ -114,6 +115,58 @@ func TestAdapter_Handle_BinaryResponse(t *testing.T) {
 	}
 	if resp.Body != "YmluYXJ5LWRhdGE=" {
 		t.Errorf("expected base64-encoded body, got %q", resp.Body)
+	}
+}
+
+func TestAdapter_Handle_MultipleCookies(t *testing.T) {
+	// REST API Gateway collapses Headers to one value per key, so multiple
+	// Set-Cookie headers (set one + clear another) must come through
+	// MultiValueHeaders. The single-value Headers map is left untouched.
+	handler := func(_ context.Context, _ protosource.Request) protosource.Response {
+		return protosource.Response{
+			StatusCode: http.StatusOK,
+			Headers:    map[string]string{"Content-Type": "application/json"},
+			Cookies: []*http.Cookie{
+				{Name: "shadow", Value: "session-token", Path: "/", HttpOnly: true},
+				{Name: "shadow_oauth_state", Value: "", Path: "/oauth/callback", MaxAge: -1},
+			},
+		}
+	}
+
+	resp, err := New(handler).Handle(context.Background(), events.APIGatewayProxyRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	setCookies := resp.MultiValueHeaders["Set-Cookie"]
+	if len(setCookies) != 2 {
+		t.Fatalf("expected 2 Set-Cookie values, got %d: %v", len(setCookies), setCookies)
+	}
+	if !strings.Contains(setCookies[0], "shadow=session-token") {
+		t.Errorf("expected first cookie to set shadow session, got %q", setCookies[0])
+	}
+	if !strings.Contains(setCookies[1], "shadow_oauth_state=") ||
+		!strings.Contains(setCookies[1], "Max-Age=0") {
+		t.Errorf("expected second cookie to clear shadow_oauth_state, got %q", setCookies[1])
+	}
+	// Single-value Headers remain intact and untouched by cookie handling.
+	if resp.Headers["Content-Type"] != "application/json" {
+		t.Errorf("expected Content-Type header preserved, got %q", resp.Headers["Content-Type"])
+	}
+}
+
+func TestAdapter_Handle_NoCookiesLeavesMultiValueNil(t *testing.T) {
+	// Backward-compat: a response with no Cookies must not populate
+	// MultiValueHeaders at all.
+	handler := func(_ context.Context, _ protosource.Request) protosource.Response {
+		return protosource.Response{StatusCode: http.StatusOK, Body: "ok"}
+	}
+	resp, err := New(handler).Handle(context.Background(), events.APIGatewayProxyRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.MultiValueHeaders != nil {
+		t.Errorf("expected nil MultiValueHeaders, got %v", resp.MultiValueHeaders)
 	}
 }
 

--- a/adapters/httpstandard/adapter.go
+++ b/adapters/httpstandard/adapter.go
@@ -61,6 +61,12 @@ func Wrap(handler protosource.HandlerFunc) http.HandlerFunc {
 		for k, v := range resp.Headers {
 			w.Header().Set(k, v)
 		}
+		// http.SetCookie uses Header().Add, so each cookie becomes its own
+		// Set-Cookie line — multiple cookies survive where the Headers map
+		// (one value per key) could not.
+		for _, c := range resp.Cookies {
+			http.SetCookie(w, c)
+		}
 		w.WriteHeader(resp.StatusCode)
 		_, _ = io.WriteString(w, resp.Body)
 	}
@@ -103,6 +109,12 @@ func WrapRouter(router *protosource.Router) http.Handler {
 
 		for k, v := range resp.Headers {
 			w.Header().Set(k, v)
+		}
+		// http.SetCookie uses Header().Add, so each cookie becomes its own
+		// Set-Cookie line — multiple cookies survive where the Headers map
+		// (one value per key) could not.
+		for _, c := range resp.Cookies {
+			http.SetCookie(w, c)
 		}
 		w.WriteHeader(resp.StatusCode)
 		_, _ = io.WriteString(w, resp.Body)

--- a/adapters/httpstandard/adapter_test.go
+++ b/adapters/httpstandard/adapter_test.go
@@ -67,16 +67,15 @@ func TestWrap_EmitsMultipleSetCookieHeaders(t *testing.T) {
 		t.Fatalf("expected 2 Set-Cookie headers, got %d: %v", len(setCookies), setCookies)
 	}
 
-	cookies := rec.Result().Cookies()
-	byName := map[string]*http.Cookie{}
-	for _, c := range cookies {
-		byName[c.Name] = c
+	// Assert on the raw Set-Cookie wire values. A cleared cookie (MaxAge<0)
+	// serializes as "Max-Age=0", which is the bytes the client actually sees;
+	// checking the raw header avoids depending on net/http's round-trip parse.
+	joined := strings.Join(setCookies, "\n")
+	if !strings.Contains(joined, "shadow=session-token") {
+		t.Errorf("expected shadow cookie set to session-token, got %v", setCookies)
 	}
-	if got := byName["shadow"]; got == nil || got.Value != "session-token" {
-		t.Errorf("expected shadow cookie set to session-token, got %+v", got)
-	}
-	if got := byName["shadow_oauth_state"]; got == nil || got.MaxAge >= 0 {
-		t.Errorf("expected shadow_oauth_state cookie cleared (MaxAge<0), got %+v", got)
+	if !strings.Contains(joined, "shadow_oauth_state=") || !strings.Contains(joined, "Max-Age=0") {
+		t.Errorf("expected shadow_oauth_state cookie cleared (Max-Age=0), got %v", setCookies)
 	}
 }
 

--- a/adapters/httpstandard/adapter_test.go
+++ b/adapters/httpstandard/adapter_test.go
@@ -45,6 +45,54 @@ func TestWrap(t *testing.T) {
 	}
 }
 
+func TestWrap_EmitsMultipleSetCookieHeaders(t *testing.T) {
+	// A login/rotation response must set one cookie and clear another in the
+	// same reply. The single-value Headers map can hold only one Set-Cookie,
+	// so cookies travel through Response.Cookies and each becomes its own line.
+	handler := func(_ context.Context, _ protosource.Request) protosource.Response {
+		return protosource.Response{
+			StatusCode: http.StatusOK,
+			Cookies: []*http.Cookie{
+				{Name: "shadow", Value: "session-token", Path: "/", HttpOnly: true},
+				{Name: "shadow_oauth_state", Value: "", Path: "/oauth/callback", MaxAge: -1},
+			},
+		}
+	}
+
+	rec := httptest.NewRecorder()
+	Wrap(handler)(rec, httptest.NewRequest(http.MethodPost, "/oauth/callback", nil))
+
+	setCookies := rec.Result().Header.Values("Set-Cookie")
+	if len(setCookies) != 2 {
+		t.Fatalf("expected 2 Set-Cookie headers, got %d: %v", len(setCookies), setCookies)
+	}
+
+	cookies := rec.Result().Cookies()
+	byName := map[string]*http.Cookie{}
+	for _, c := range cookies {
+		byName[c.Name] = c
+	}
+	if got := byName["shadow"]; got == nil || got.Value != "session-token" {
+		t.Errorf("expected shadow cookie set to session-token, got %+v", got)
+	}
+	if got := byName["shadow_oauth_state"]; got == nil || got.MaxAge >= 0 {
+		t.Errorf("expected shadow_oauth_state cookie cleared (MaxAge<0), got %+v", got)
+	}
+}
+
+func TestWrap_NoCookiesUnchanged(t *testing.T) {
+	// Backward-compat: a response that leaves Cookies nil emits no Set-Cookie.
+	handler := func(_ context.Context, _ protosource.Request) protosource.Response {
+		return protosource.Response{StatusCode: http.StatusOK, Body: "ok"}
+	}
+	rec := httptest.NewRecorder()
+	Wrap(handler)(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if got := rec.Result().Header.Values("Set-Cookie"); len(got) != 0 {
+		t.Errorf("expected no Set-Cookie headers, got %v", got)
+	}
+}
+
 func TestWrap_PopulatesHostHeader(t *testing.T) {
 	// net/http strips Host from r.Header into r.Host, so the adapter must
 	// re-inject it. Downstream same-origin CSRF checks (e.g. protosource-auth

--- a/docs/decisions/0002-multi-cookie-response-support.md
+++ b/docs/decisions/0002-multi-cookie-response-support.md
@@ -1,0 +1,60 @@
+# 0002. Multi-cookie response support via `[]*http.Cookie`
+
+- Status: Accepted
+- Date: 2026-06-26
+
+## Context
+
+`protosource.Response` modeled headers solely as `Headers map[string]string`. A
+Go map holds one value per key, so a handler could emit at most one `Set-Cookie`
+header per response, and both shipped adapters then rendered that map with
+`w.Header().Set` / the API Gateway single-value `Headers` field — so even a
+multi-value-capable transport never received more than one cookie.
+
+This blocked the common "set one cookie **and** clear another in the same
+response" pattern at the framework level: login/logout, session rotation, and
+the OAuth2/OIDC PKCE `/oauth/callback` flow in protosource-auth (set the
+`shadow` session cookie while clearing the consumed `shadow_oauth_state` cookie).
+See GH#103.
+
+Two sub-decisions were weighed: (a) how to express cookies on the transport-neutral
+`Response`, and (b) how the awslambda adapter renders them, since both shipped
+adapters target `events.APIGatewayProxyResponse` (REST / proxy v1).
+
+## Decision
+
+Add a `Cookies []*http.Cookie` field to `Response`. Each entry renders as its own
+`Set-Cookie` header; the existing single-value `Headers` semantics are untouched,
+so responses that leave `Cookies` nil behave exactly as before.
+
+- **httpstandard:** after applying `Headers`, loop `http.SetCookie(w, c)` for each
+  cookie (uses `Header().Add`, emitting multiple `Set-Cookie` lines).
+- **awslambda:** render cookies into `MultiValueHeaders["Set-Cookie"]`, skipping
+  any cookie whose `http.Cookie.String()` is empty (invalid). `MultiValueHeaders`
+  stays nil when `Cookies` is empty.
+
+## Rejected alternatives
+
+- **Expose `MultiValueHeaders map[string][]string` on `Response`** — rejected
+  because it leaks an AWS-/transport-specific shape into the cloud-agnostic core,
+  pushes cookie encoding (attributes, expiry, escaping) onto every handler, and
+  has no clean rendering for the httpstandard adapter.
+- **Keep `Headers` and special-case a magic newline-joined `Set-Cookie` value** —
+  rejected as a fragile encoding hack that breaks the stdlib cookie contract and
+  surprises handler authors.
+- **Target API Gateway HTTP API v2 (`APIGatewayV2HTTPResponse.Cookies []string`)**
+  — rejected for now because both shipped adapters use the v1 proxy type
+  (`APIGatewayProxyResponse`); there is no v2 handler in the repo. `MultiValueHeaders`
+  is the correct mechanism for v1 REST APIs. A v2 adapter can map `Response.Cookies`
+  to the native `Cookies` field if/when one is added — the `Response` shape already
+  supports it.
+
+## Consequences
+
+- Handlers can set and clear multiple cookies in one response across both adapters;
+  unblocks protosource-auth's explicit OAuth-state-cookie clearing and a proper
+  federated `/oauth/logout`.
+- Fully backward compatible: no change for handlers that don't set `Cookies`.
+- `Response` now imports `net/http`, a stdlib-only dependency.
+- A future v2 adapter must map `Cookies` to `APIGatewayV2HTTPResponse.Cookies`
+  rather than `MultiValueHeaders`; the v1 path documents why.

--- a/protosource.go
+++ b/protosource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"reflect"
 	"strings"
 	"time"
@@ -609,6 +610,13 @@ type Response struct {
 	StatusCode int
 	Body       string
 	Headers    map[string]string
+	// Cookies are rendered as separate Set-Cookie headers, one per entry.
+	// This is the cloud-agnostic way to emit multiple cookies in a single
+	// response (e.g. set a session cookie while clearing a transient one),
+	// which the single-value Headers map cannot express. Adapters render
+	// each cookie independently; Headers semantics are unaffected, so a
+	// response that leaves Cookies nil behaves exactly as before.
+	Cookies []*http.Cookie
 }
 
 // HandlerFunc is the signature for provider-agnostic request handlers.


### PR DESCRIPTION
## Summary

`protosource.Response` modeled headers as `Headers map[string]string`, which holds one value per key — so a handler could emit **at most one `Set-Cookie` header per response**, and both shipped adapters rendered it single-valued. This blocked the common "set one cookie **and** clear another in the same response" pattern (login/logout, session rotation, OAuth2/OIDC PKCE `/oauth/callback`). Fixes #103.

## What changed

- **`protosource.go`** — add a cloud-agnostic `Cookies []*http.Cookie` field to `Response`. Each entry renders as its own `Set-Cookie` header; existing `Headers` semantics are untouched.
- **`adapters/httpstandard`** — both `Wrap` and `WrapRouter` loop `http.SetCookie(w, c)` (uses `Header().Add`, emitting multiple `Set-Cookie` lines).
- **`adapters/awslambda`** — `encodeResponse` renders cookies into `MultiValueHeaders["Set-Cookie"]` (REST / proxy v1), skipping invalid cookies; leaves `MultiValueHeaders` nil when there are none.

## Why `[]*http.Cookie` + v1 `MultiValueHeaders`

Recorded in [`docs/decisions/0002-multi-cookie-response-support.md`](docs/decisions/0002-multi-cookie-response-support.md):
- `[]*http.Cookie` keeps the abstraction transport-neutral and reuses stdlib cookie encoding, rather than leaking AWS-specific `MultiValueHeaders` into the core.
- Both shipped adapters target the v1 proxy type (`APIGatewayProxyResponse`); there is no v2 handler in the repo, so `MultiValueHeaders` is the correct v1 mechanism. A future v2 adapter can map `Response.Cookies` to the native `Cookies` field.

## Backward compatibility

Fully backward compatible — a response that leaves `Cookies` nil behaves exactly as before. No codegen changes (cookie-setting handlers are hand-written downstream).

## Tests

- httpstandard & awslambda: multiple `Set-Cookie` emission, a set + clear (`MaxAge<0`) pair, and the empty-`Cookies` path.
- Verified single-value `Headers` remain intact alongside cookies.
- `go build ./...`, `go test ./adapters/...`, `go vet` all pass.

## Downstream

Unblocks protosource-auth: explicitly clearing the OAuth state cookie on `/oauth/callback`, and a proper federated `/oauth/logout`.